### PR TITLE
Disable untested `zn.plots` feature

### DIFF
--- a/zntrack/zn/__init__.py
+++ b/zntrack/zn/__init__.py
@@ -29,9 +29,9 @@ class outs(ZnTrackOption):
     load = True
 
 
-class plots(ZnTrackOption):
-    option = "plots"
-    load = True
+# class plots(ZnTrackOption):
+#     option = "plots"
+#     load = True
 
 
 class metrics(ZnTrackOption):


### PR DESCRIPTION
In #98 the feature for `zn.plots()` was merged.
This feature was not ready to be pushed to main yet and has to be fixed according to #116 

This PR will disable the feature until it is fixed.