### PR TITLE
[MetaData] add mean/std

### DIFF
--- a/CI/integration_tests/metadata/test_metadata_timeit.py
+++ b/CI/integration_tests/metadata/test_metadata_timeit.py
@@ -45,6 +45,34 @@ class SleepNodeMulti:
         sleep(time)
 
 
+@Node()
+class SleepNodeInit:
+    @TimeIt()
+    def run(self):
+        self.sleep_2()
+        self.sleep_5()
+
+    @TimeIt()
+    def sleep_5(self):
+        sleep(5)
+
+    @TimeIt()
+    def sleep_2(self):
+        sleep(2)
+
+
+@Node()
+class SleepNodeMultiInit:
+    def run(self):
+        self.sleep(1)
+        self.sleep(2)
+        self.sleep(3)
+
+    @TimeIt()
+    def sleep(self, time):
+        sleep(time)
+
+
 def test_timeit(tmp_path):
     """Test that the timeit decorator works"""
     shutil.copy(__file__, tmp_path)
@@ -77,6 +105,46 @@ def test_timeit_multi(tmp_path):
     project.repro()
 
     metadata = SleepNodeMulti(load=True).metadata
+
+    assert len(metadata) == 3
+
+    np.testing.assert_almost_equal(metadata["sleep:timeit"], 1.0, decimal=1)
+    np.testing.assert_almost_equal(metadata["sleep_1:timeit"], 2.0, decimal=1)
+    np.testing.assert_almost_equal(metadata["sleep_2:timeit"], 3.0, decimal=1)
+
+
+def test_timeit_init(tmp_path):
+    """Test that the timeit decorator works"""
+    shutil.copy(__file__, tmp_path)
+    os.chdir(tmp_path)
+    project = ZnTrackProject()
+    project.create_dvc_repository()
+
+    SleepNodeInit()()
+
+    project.repro()
+
+    metadata = SleepNodeInit(load=True).metadata
+
+    assert len(metadata) == 3
+
+    np.testing.assert_almost_equal(metadata["sleep_2:timeit"], 2.0, decimal=1)
+    np.testing.assert_almost_equal(metadata["sleep_5:timeit"], 5.0, decimal=1)
+    np.testing.assert_almost_equal(metadata["run:timeit"], 7.0, decimal=1)
+
+
+def test_timeit_multi_init(tmp_path):
+    """Test that the timeit decorator works multiple times on the same method"""
+    shutil.copy(__file__, tmp_path)
+    os.chdir(tmp_path)
+    project = ZnTrackProject()
+    project.create_dvc_repository()
+
+    SleepNodeMultiInit()()
+
+    project.repro()
+
+    metadata = SleepNodeMultiInit(load=True).metadata
 
     assert len(metadata) == 3
 

--- a/CI/integration_tests/metadata/test_metadata_timeitmean.py
+++ b/CI/integration_tests/metadata/test_metadata_timeitmean.py
@@ -41,6 +41,6 @@ def test_timeitmean(tmp_path):
 
     metadata = SleepNode(load=True).metadata
 
-    np.testing.assert_almost_equal(metadata["sleep:TimeItMean"]['mean'], 1.0, decimal=3)
-    np.testing.assert_almost_equal(metadata["sleep:TimeItMean"]['std'], 0.0, decimal=3)
-    assert metadata["sleep:TimeItMean"]['runs'] == 10
+    np.testing.assert_almost_equal(metadata["sleep:TimeItMean"]["mean"], 1.0, decimal=3)
+    np.testing.assert_almost_equal(metadata["sleep:TimeItMean"]["std"], 0.0, decimal=3)
+    assert metadata["sleep:TimeItMean"]["runs"] == 10

--- a/CI/integration_tests/metadata/test_metadata_timeitmean.py
+++ b/CI/integration_tests/metadata/test_metadata_timeitmean.py
@@ -1,0 +1,46 @@
+"""
+This program and the accompanying materials are made available under the terms of the
+Eclipse Public License v2.0 which accompanies this distribution, and is available at
+https://www.eclipse.org/legal/epl-v20.html
+SPDX-License-Identifier: EPL-2.0
+
+Copyright Contributors to the Zincware Project.
+
+Description:
+"""
+
+from zntrack import Node, ZnTrackProject
+from zntrack.metadata import TimeItMean
+from time import sleep
+import os
+import shutil
+import numpy as np
+
+
+@Node()
+class SleepNode:
+    def run(self):
+        for _ in range(10):
+            self.sleep(1)
+
+    @TimeItMean
+    def sleep(self, time):
+        sleep(time)
+
+
+def test_timeitmean(tmp_path):
+    """Test that the timeitMean decorator works"""
+    shutil.copy(__file__, tmp_path)
+    os.chdir(tmp_path)
+    project = ZnTrackProject()
+    project.create_dvc_repository()
+
+    SleepNode()()
+
+    project.repro()
+
+    metadata = SleepNode(load=True).metadata
+
+    np.testing.assert_almost_equal(metadata["sleep:TimeItMean"]['mean'], 1.0, decimal=3)
+    np.testing.assert_almost_equal(metadata["sleep:TimeItMean"]['std'], 0.0, decimal=3)
+    assert metadata["sleep:TimeItMean"]['runs'] == 10

--- a/zntrack/core/decorator.py
+++ b/zntrack/core/decorator.py
@@ -232,7 +232,7 @@ class Node:
 
             cls.zntrack.pre_init()
             log.debug(f"Processing {cls.zntrack}")
-            result = func(cls, *args, **kwargs)
+            parsed_function = func(cls, *args, **kwargs)
             cls.zntrack.post_init()
 
             if self.nb_name is not None:
@@ -242,7 +242,7 @@ class Node:
             if cls.zntrack.module == "__main__":
                 cls.zntrack._module = Path(sys.argv[0]).stem
 
-            return result
+            return parsed_function
 
         return wrapper
 
@@ -287,9 +287,9 @@ class Node:
 
             """
             cls.zntrack.pre_call()
-            function = func(cls, *args, **kwargs)
+            parsed_function = func(cls, *args, **kwargs)
             cls.zntrack.post_call(force, exec_, always_changed, slurm, silent)
-            return function
+            return parsed_function
 
         return wrapper
 
@@ -301,8 +301,8 @@ class Node:
         def wrapper(cls: TypeHintParent):
             """Wrapper around the run method"""
             cls.zntrack.pre_run()
-            function = func(cls)
+            parsed_function = func(cls)
             cls.zntrack.post_run()
-            return function
+            return parsed_function
 
         return wrapper

--- a/zntrack/core/decorator.py
+++ b/zntrack/core/decorator.py
@@ -300,6 +300,7 @@ class Node:
         @functools.wraps(func)
         def wrapper(cls: TypeHintParent):
             """Wrapper around the run method"""
+            print("Creating Run Decorator")
             cls.zntrack.pre_run()
             parsed_function = func(cls)
             cls.zntrack.post_run()

--- a/zntrack/metadata/__init__.py
+++ b/zntrack/metadata/__init__.py
@@ -9,6 +9,6 @@ Copyright Contributors to the Zincware Project.
 Description: meta data collections such as execution times
 """
 from .base import MetaData
-from .decorators import TimeIt
+from .decorators import TimeIt, TimeItMean
 
-__all__ = ["MetaData", "TimeIt"]
+__all__ = ["MetaData", "TimeIt", "TimeItMean"]

--- a/zntrack/metadata/decorators.py
+++ b/zntrack/metadata/decorators.py
@@ -21,7 +21,7 @@ class TimeIt(MetaData):
 
     name_of_metric = "timeit"
 
-    def __call__(self, cls, *args, **kwargs):
+    def call(self, cls, *args, **kwargs):
         """Measure the execution time by storing the time
         before and after the function call
         """
@@ -38,6 +38,9 @@ class TimeItMean(MetaData):
     """TimeIt decorator that computes the mean and std over multiple runs"""
 
     name_of_metric = "TimeItMean"
+
+    def call(self, cls, *args, **kwargs):
+        pass
 
     def __call__(self, cls: TypeHintParent, *args, **kwargs):
         """Measure the execution time by storing the time

--- a/zntrack/metadata/decorators.py
+++ b/zntrack/metadata/decorators.py
@@ -13,7 +13,7 @@ from .base import MetaData
 from time import time
 import statistics
 import json
-from pathlib import Path
+from zntrack.utils.type_hints import TypeHintParent
 
 
 class TimeIt(MetaData):
@@ -39,7 +39,7 @@ class TimeItMean(MetaData):
 
     name_of_metric = "TimeItMean"
 
-    def __call__(self, cls, *args, **kwargs):
+    def __call__(self, cls: TypeHintParent, *args, **kwargs):
         """Measure the execution time by storing the time
         before and after the function call
         """
@@ -47,14 +47,12 @@ class TimeItMean(MetaData):
         parsed_func = self.func(cls, *args, **kwargs)
         stop_time = time()
 
-        # TODO this should use a proper temp file, we can generate one and
-        #  have clean up command as post_run command. Maybe have
-        #  cls.zntrack.get_temp_file(key=name_of_metric_func_name) -> Path
-        tmp_file = Path(f"{self.name_of_metric}_{self.func_name}.json")
+        tmp_file_name = f"{self.name_of_metric}_{self.func_name}.json"
+        tmp_file = cls.zntrack.get_temporary_file(name=tmp_file_name)
 
         try:
             data = json.loads(tmp_file.read_text())
-        except FileNotFoundError:
+        except json.decoder.JSONDecodeError:
             data = []
 
         data.append(stop_time - start_time)

--- a/zntrack/metadata/decorators.py
+++ b/zntrack/metadata/decorators.py
@@ -11,6 +11,9 @@ Description:
 
 from .base import MetaData
 from time import time
+import statistics
+import json
+from pathlib import Path
 
 
 class TimeIt(MetaData):
@@ -27,5 +30,45 @@ class TimeIt(MetaData):
         stop_time = time()
 
         self.save_metadata(cls, value=stop_time - start_time)
+
+        return parsed_func
+
+
+class TimeItMean(MetaData):
+    """TimeIt decorator that computes the mean and std over multiple runs"""
+
+    name_of_metric = "TimeItMean"
+
+    def __call__(self, cls, *args, **kwargs):
+        """Measure the execution time by storing the time
+        before and after the function call
+        """
+        start_time = time()
+        parsed_func = self.func(cls, *args, **kwargs)
+        stop_time = time()
+
+        # TODO this should use a proper temp file, we can generate one and
+        #  have clean up command as post_run command. Maybe have
+        #  cls.zntrack.get_temp_file(key=name_of_metric_func_name) -> Path
+        tmp_file = Path(f"{self.name_of_metric}_{self.func_name}.json")
+
+        try:
+            data = json.loads(tmp_file.read_text())
+        except FileNotFoundError:
+            data = []
+
+        data.append(stop_time - start_time)
+        try:
+            mean = statistics.mean(data)
+            std = statistics.stdev(data)
+        except statistics.StatisticsError:
+            mean = data[0]
+            std = 0
+
+        tmp_file.write_text(json.dumps(data))
+
+        self.save_metadata(
+            cls, value={"mean": mean, "std": std, "runs": len(data)}, use_regex=False
+        )
 
         return parsed_func

--- a/zntrack/utils/type_hints.py
+++ b/zntrack/utils/type_hints.py
@@ -9,10 +9,8 @@ Copyright Contributors to the Zincware Project.
 Description: Type hinting class for IDE autocompletion
 """
 from zntrack.core.zntrack import ZnTrackParent
-from zntrack.core.parameter import DVC
 
 
 class TypeHintParent:
     def __init__(self):
         self.zntrack: ZnTrackParent = ZnTrackParent(child=self)
-        self._executed = DVC.result()


### PR DESCRIPTION
In comparison to `@TimeIt` this decorator can be used e.g. for debugging a function.

```py
@Node()
class SleepTest:
    @TimeItMean
    def sleep(self):
        sleep(1)
    
    def run(self):
        for _ in range(10):
            self.sleep()
```

`SleepTest(load=True).metadata`  gives
```json
{'sleep:TimeItMean': {'mean': 1.0071059703826903,
  'std': 0.004479182352446432,
  'runs': 10}}
```

# TODOs
- [ ] Documentation
- [ ] Tests
- [x] fix temp_file ToDo
- [ ] make it `@TimeIt(mean=True)` instead of a different decorator
- [ ] fix issues with double decorator / descriptor problems


```py
Node(silent=True)
class SleepNode:
    
    @TimeIt
    def run(self):
        print("GOT HERE?!")
        self.sleep_1s()
        self.sleep_2s()
    
    def sleep_1s(self):
        sleep(1)
    
    def sleep_2s(self):
        sleep(2)

SleepNode(load=True).run() # returns a function
```