### PR TITLE
Add Support for missing DVC Options

### DIFF
--- a/CI/integration_tests/test_exec_node.py
+++ b/CI/integration_tests/test_exec_node.py
@@ -13,7 +13,7 @@ import shutil
 import os
 
 
-@Node(exec_=True)
+@Node(no_exec=False)
 class HelloWorld:
     """BasicTest class"""
 

--- a/docs/source/_overview/OptionalDVC.ipynb
+++ b/docs/source/_overview/OptionalDVC.ipynb
@@ -1,0 +1,284 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "11e1b3ea-4c78-4a2e-a815-09d350e38a1b",
+   "metadata": {},
+   "source": [
+    "# Optional DVC arguments\n",
+    "\n",
+    "There are more DVC Options https://dvc.org/doc/command-reference/run#options that can be important to some workflows.\n",
+    "In the following we show how to use them with DVC."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "226295e7-424a-45d3-9e16-c91e7f3fabd7",
+   "metadata": {},
+   "source": [
+    "## External\n",
+    "\n",
+    "For `dvc run --external` the following can be used:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "053af217-bf4f-485d-9892-e71d83824bbd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from zntrack import Node, dvc, config, ZnTrackProject\n",
+    "from pathlib import Path\n",
+    "import tempfile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e6dd042e-4530-49ab-91ee-bb3fb732cd5d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-11-23 17:16:11,898 (INFO): Setting up GIT/DVC repository.\n"
+     ]
+    }
+   ],
+   "source": [
+    "project = ZnTrackProject()\n",
+    "project.create_dvc_repository()\n",
+    "config.nb_name = \"OptionalDVC.ipynb\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8d7cc118-afb0-4dfa-be71-793574febd34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "temp_file = tempfile.NamedTemporaryFile()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "026f89e2-e814-4b9c-a896-dac94353c404",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-11-23 17:16:14,552 (WARNING): Jupyter support is an experimental feature! Please save your notebook before running this command!\n",
+      "Submit issues to https://github.com/zincware/ZnTrack.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[NbConvertApp] Converting notebook OptionalDVC.ipynb to script\n",
+      "[NbConvertApp] Writing 1543 bytes to OptionalDVC.py\n"
+     ]
+    }
+   ],
+   "source": [
+    "@Node(external=True)\n",
+    "class WriteExternal:\n",
+    "    file: Path = dvc.outs()\n",
+    "    data = dvc.params()\n",
+    "    \n",
+    "    def __call__(self, data: str, file: str):\n",
+    "        self.data = data\n",
+    "        self.file = Path(file)\n",
+    "        \n",
+    "    def run(self):\n",
+    "        self.file.write_text(self.data)\n",
+    "    \n",
+    "    def read_text(self):\n",
+    "        print(self.file.read_text())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ded6611c-2bea-43ae-aa51-0c714d0c29f0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-11-23 17:16:18,280 (WARNING): --- Writing new DVC file! ---\n",
+      "2021-11-23 17:16:21,729 (INFO): Creating 'dvc.yaml'\n",
+      "Adding stage 'WriteExternal' in 'dvc.yaml'\n",
+      "\n",
+      "To track the changes with git, run:\n",
+      "\n",
+      "\tgit add dvc.yaml\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "WriteExternal()(data=\"HelloWorld\", file=temp_file.name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ebda1030-b38b-48da-99b6-32e382515c4e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running stage 'WriteExternal':\n",
+      "> python3 -c \"from src.WriteExternal import WriteExternal; WriteExternal(load=True, name='WriteExternal').run()\" \n",
+      "Generating lock file 'dvc.lock'\n",
+      "Updating lock file 'dvc.lock'\n",
+      "\n",
+      "To track the changes with git, run:\n",
+      "\n",
+      "\tgit add dvc.lock\n",
+      "Use `dvc push` to send your updates to remote storage.\n"
+     ]
+    }
+   ],
+   "source": [
+    "project.repro()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "666c7ccb-08e0-4e6a-9a06-1e7a0ba242ef",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "HelloWorld\n"
+     ]
+    }
+   ],
+   "source": [
+    "WriteExternal(load=True).read_text()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "11ce904a-70b0-456e-8330-932eeeba2f08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "temp_file.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40d5645d-7158-4956-abc0-6f5cb9698d37",
+   "metadata": {},
+   "source": [
+    "# no-commit\n",
+    "For `dvc run --no-commit` the interface is similar and looks like:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "3ec9c511-1ed3-4844-a420-dbbf2cc82423",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-11-23 17:16:25,526 (WARNING): Jupyter support is an experimental feature! Please save your notebook before running this command!\n",
+      "Submit issues to https://github.com/zincware/ZnTrack.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[NbConvertApp] Converting notebook OptionalDVC.ipynb to script\n",
+      "[NbConvertApp] Writing 1543 bytes to OptionalDVC.py\n"
+     ]
+    }
+   ],
+   "source": [
+    "@Node(no_commit=True)\n",
+    "class HelloWorld:\n",
+    "    def run(self):\n",
+    "        pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8fc9d1f2-2235-4e8c-9432-94f940b440fa",
+   "metadata": {},
+   "source": [
+    "For `dvc run --no-exec` you can pass `no_exec=True`. This is the default value, because Experiments are usually queued and then run collectively if the full graph was build."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "afddeca2-d1d4-4eaa-8628-ff6cbfa1bbe1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-11-23 17:16:29,342 (WARNING): Jupyter support is an experimental feature! Please save your notebook before running this command!\n",
+      "Submit issues to https://github.com/zincware/ZnTrack.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[NbConvertApp] Converting notebook OptionalDVC.ipynb to script\n",
+      "[NbConvertApp] Writing 1543 bytes to OptionalDVC.py\n"
+     ]
+    }
+   ],
+   "source": [
+    "@Node(no_exec=True)\n",
+    "class HelloWorld:\n",
+    "    def run(self):\n",
+    "        pass"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,6 +34,7 @@ information or write an issue on Github for https://github.com/zincware/ZnTrack
    _overview/04_metrics_and_plots.ipynb
    _overview/05_metadata.ipynb
    _overview/06_named_nodes.ipynb
+   _overview/OptionalDVC.ipynb
    jupyter.rst
 
 .. toctree::

--- a/zntrack/core/data_classes.py
+++ b/zntrack/core/data_classes.py
@@ -20,6 +20,53 @@ log = logging.getLogger(__name__)
 
 
 @dataclass(frozen=False, order=True, init=True)
+class DVCOptions:
+    """Extension to the DVCParams
+
+    DVCParams handles e.g. I/O whilst DVCOptions handles all other parameters,
+    such as the name, exec, force, commit, external, ...
+
+    See Also
+    --------
+    https://dvc.org/doc/command-reference/run
+    """
+
+    no_commit: bool = False
+    external: bool = False
+    always_changed: bool = False
+    no_exec: bool = False
+    force: bool = False
+    no_run_cache: bool = False
+
+    def get_dvc_arguments(self) -> list:
+        """Get the activated options
+
+        Returns
+        -------
+        list: A list of strings for the subprocess call
+            ["--no-commit", "--external"]
+
+        """
+        out = []
+
+        for dvc_option in self.__dataclass_fields__:
+            value = getattr(self, dvc_option)
+            if isinstance(value, bool):
+                if value:
+                    out.append(f"--{dvc_option.replace('_', '-')}")
+                else:
+                    if dvc_option == "no_exec":
+                        log.warning(
+                            "You will not be able to see the stdout/stderr "
+                            "of the process in real time!"
+                        )
+            else:
+                raise NotImplementedError("Currently only boolean values are supported")
+
+        return out
+
+
+@dataclass(frozen=False, order=True, init=True)
 class DVCParams:
     """PyTracks DVCParams"""
 

--- a/zntrack/core/decorator.py
+++ b/zntrack/core/decorator.py
@@ -73,7 +73,11 @@ class Node:
             raise ValueError("Please use `@Node()` instead of `@Node`.")
         self.cls = cls
 
-        self.no_exec = no_exec
+        if 'exec_' in kwargs:
+            self.no_exec = not kwargs.get('exec_')
+            log.warning("DeprecationWarning: Please use no_exec instead of exec_")
+        else:
+            self.no_exec = no_exec
         self.external = external
         self.no_commit = no_commit
         self.silent = silent
@@ -312,6 +316,10 @@ class Node:
             decorated class
 
             """
+
+            if 'exec_' in kwargs:
+                no_exec = not kwargs.pop('exec_')
+                log.warning("DeprecationWarning: Please use no_exec instead of exec_")
 
             dvc_options = DVCOptions(
                 force=force,

--- a/zntrack/core/decorator.py
+++ b/zntrack/core/decorator.py
@@ -38,6 +38,7 @@ class Node:
         name: str = None,
         exec_: bool = False,
         silent: bool = False,
+        external_data: bool = False,
         **kwargs,
     ):
         """
@@ -59,6 +60,9 @@ class Node:
         silent: bool
             If called with exec_=True this allows to hide the output from the
             subprocess call.
+        external_data: bool, default = False
+            Add the `--external` argument to the dvc run command, that indicates that
+            outs or deps can be located outside of the repository
         kwargs: No kwargs are implemented
         """
         if cls is not None:
@@ -66,6 +70,7 @@ class Node:
         self.cls = cls
 
         self.exec_ = exec_
+        self.external_data = external_data
         self.silent = silent
 
         self.name = name
@@ -235,7 +240,12 @@ class Node:
                 log.debug("DeprecationWarning: Argument id_ will be removed eventually")
                 load = True
 
-            cls.zntrack.pre_init(name=name, load=load, has_metadata=self.has_metadata)
+            cls.zntrack.pre_init(
+                name=name,
+                load=load,
+                has_metadata=self.has_metadata,
+                external_data=self.external_data,
+            )
             log.debug(f"Processing {cls.zntrack}")
             parsed_function = func(cls, *args, **kwargs)
             cls.zntrack.post_init()

--- a/zntrack/core/decorator.py
+++ b/zntrack/core/decorator.py
@@ -40,6 +40,7 @@ class Node:
         no_exec: bool = True,
         silent: bool = False,
         external: bool = False,
+        no_commit: bool = False,
         **kwargs,
     ):
         """
@@ -61,9 +62,11 @@ class Node:
         silent: bool
             If called with no_exec=False this allows to hide the output from the
             subprocess call.
-        external bool, default = False
+        external: bool, default = False
             Add the `--external` argument to the dvc run command, that indicates that
             outs or deps can be located outside of the repository
+        no_commit: bool, default=False
+            Add the `--no-commit` argument to the dvc run command
         kwargs: No kwargs are implemented
         """
         if cls is not None:
@@ -72,6 +75,7 @@ class Node:
 
         self.no_exec = no_exec
         self.external = external
+        self.no_commit = no_commit
         self.silent = silent
 
         self.name = name
@@ -274,6 +278,7 @@ class Node:
             slurm=False,
             silent=self.silent,
             external=self.external,
+            no_commit=self.no_commit,
             **kwargs,
         ):
             """Wrapper around the call
@@ -286,7 +291,7 @@ class Node:
                 Args to be passed to the class
             force: bool
                 Whether to use dvc with the force argument
-            no_exec: bool
+            no_exec: bool, default=True
                 Whether to use dvc with the no_exec argument
             always_changed: bool
                 Whether to use dvc with the always_changed argument
@@ -298,6 +303,8 @@ class Node:
             external: bool, default = False
                 Add the `--external` argument to the dvc run command, that indicates
                 that outs or deps can be located outside of the repository
+            no_commit: bool, default=False
+                Add the `no-commit` dvc run argument.
             kwargs
 
             Returns
@@ -311,6 +318,7 @@ class Node:
                 no_exec=no_exec,
                 always_changed=always_changed,
                 external=external,
+                no_commit=no_commit,
             )
 
             cls.zntrack.pre_call()

--- a/zntrack/core/decorator.py
+++ b/zntrack/core/decorator.py
@@ -73,8 +73,8 @@ class Node:
             raise ValueError("Please use `@Node()` instead of `@Node`.")
         self.cls = cls
 
-        if 'exec_' in kwargs:
-            self.no_exec = not kwargs.get('exec_')
+        if "exec_" in kwargs:
+            self.no_exec = not kwargs.get("exec_")
             log.warning("DeprecationWarning: Please use no_exec instead of exec_")
         else:
             self.no_exec = no_exec
@@ -317,8 +317,8 @@ class Node:
 
             """
 
-            if 'exec_' in kwargs:
-                no_exec = not kwargs.pop('exec_')
+            if "exec_" in kwargs:
+                no_exec = not kwargs.pop("exec_")
                 log.warning("DeprecationWarning: Please use no_exec instead of exec_")
 
             dvc_options = DVCOptions(

--- a/zntrack/core/decorator.py
+++ b/zntrack/core/decorator.py
@@ -19,6 +19,7 @@ import typing
 import functools
 
 from .zntrack import ZnTrackProperty
+from zntrack.core.data_classes import DVCOptions
 from zntrack.utils import config
 from zntrack.metadata import MetaData
 
@@ -304,15 +305,20 @@ class Node:
             decorated class
 
             """
-            cls.zntrack.pre_call()
-            parsed_function = func(cls, *args, **kwargs)
-            cls.zntrack.post_call(
+
+            dvc_options = DVCOptions(
                 force=force,
                 no_exec=no_exec,
                 always_changed=always_changed,
+                external=external,
+            )
+
+            cls.zntrack.pre_call()
+            parsed_function = func(cls, *args, **kwargs)
+            cls.zntrack.post_call(
+                dvc_options=dvc_options,
                 slurm=slurm,
                 silent=silent,
-                external=external,
             )
             return parsed_function
 

--- a/zntrack/core/zntrack.py
+++ b/zntrack/core/zntrack.py
@@ -142,12 +142,9 @@ class ZnTrackParent(ZnTrackType):
 
     def post_call(
         self,
-        force: bool,
-        no_exec: bool,
-        always_changed: bool,
+        dvc_options: DVCOptions,
         slurm: bool,
         silent: bool,
-        external: bool,
     ):
         """Method after call
 
@@ -156,15 +153,8 @@ class ZnTrackParent(ZnTrackType):
 
         Parameters
         ----------
-        force: bool, default=False
-            Use dvc run with `--force` to overwrite previous stages!
-        no_exec: bool, default=False
-            Run the stage directly and don't use dvc with '--no-exec'.
-            This will not output stdout/stderr in real time and should only be used
-            for fast functions!
-        always_changed: bool, default=False
-            Set the always changed dvc argument. See the official DVC docs.
-            Can be useful for debugging / development.
+        dvc_options: DVCOptions
+            Dataclass collecting all the optional DVC options, e.g. force, external,...
         slurm: bool, default=False
             Use `SRUN` with self.slurm_config for this stage - WARNING this doesn't
             mean that every stage uses slurm and you may accidentally run stages on
@@ -172,20 +162,12 @@ class ZnTrackParent(ZnTrackType):
         silent: bool
             If called with no_exec=False this allows to hide the output from the
             subprocess call.
-        external: bool, default = False
-            Add the `--external` argument to the dvc run command, that indicates that
-            outs or deps can be located outside of the repository
 
         """
         self.update_dvc()
         self.save_internals()
 
-        self.dvc_options = DVCOptions(
-            force=force,
-            no_exec=no_exec,
-            always_changed=always_changed,
-            external=external,
-        )
+        self.dvc_options = dvc_options
 
         self.write_dvc(slurm, silent)
 

--- a/zntrack/core/zntrack.py
+++ b/zntrack/core/zntrack.py
@@ -83,6 +83,7 @@ class ZnTrackParent(ZnTrackType):
         self.running = False  # is set to true, when run_dvc
         self.load = False
         self.has_metadata = False
+        self.external_data = False
 
         self.dvc_file = "dvc.yaml"
         # This is True while inside the init to avoid ValueErrors
@@ -98,7 +99,7 @@ class ZnTrackParent(ZnTrackType):
             self._zn_files = ZnFiles(node_name=self.stage_name)
         return self._zn_files
 
-    def pre_init(self, name: str, load: bool, has_metadata: bool):
+    def pre_init(self, name: str, load: bool, has_metadata: bool, external_data: bool):
         """Function to be called prior to the init
 
         Parameters
@@ -111,10 +112,14 @@ class ZnTrackParent(ZnTrackType):
         has_metadata: bool
             check by the decorator if any methods write to self.metadata.
             This can e.g. be TimeIt decorators.
+        external_data: bool, default = False
+            Add the `--external` argument to the dvc run command, that indicates that
+            outs or deps can be located outside of the repository
         """
         self.stage_name = name
         self.load = load
         self.has_metadata = has_metadata
+        self.external_data = external_data
 
     def post_init(self):
         """Post init command
@@ -379,6 +384,11 @@ class ZnTrackParent(ZnTrackType):
 
         if self.nb_mode:
             script += ["--deps", Path(*self.module.split(".")).with_suffix(".py")]
+
+        if self.external_data:
+            script.append("--external")
+            if not silent:
+                log.info("Enabling external data!")
 
         if force:
             script.append("--force")


### PR DESCRIPTION
# Changes
- move dvc arguments to new dataclass, to support more options dynamically
- renamed `exec_` to `no_exec: bool = True` in accordance with the official naming conventions. 

**THIS IS AN API CHANGE!** Depreciation Warning is added

- add support for `--external` and `--no-commit`

# TODOs
- [x] Documentation
- [x] Tests
- [x] `no_exec=True` means that the `--no-exec` argument is passed to `dvc run`. This is a little confusing, because of the naming - should this be changed? NO!


# Example
Add the `--external` argument to `dvc run` via

```py
@Node(external=True, no_commit=True)
class HelloWorld(TypeHintParent):
    dvc.outs("/work/remote_data")
```

Alternative would be to import the dataclass  directly, but I think I'll stick with the arguments, although this means writing code twice.

```py
from zntrack import DVCOptions

@Node(DVCOptions(force=True, no_run_cache=True, external=True))
class HelloWorld(TypeHintParent):
    dvc.outs("/work/remote_data")
```

