### PR TITLE
Add config option `no_dvc`

### DIFF
--- a/zntrack/core/zntrack.py
+++ b/zntrack/core/zntrack.py
@@ -19,7 +19,7 @@ from .data_classes import SlurmConfig
 from .parameter import ZnTrackOption
 from zntrack.core.data_classes import DVCParams, ZnFiles
 from pathlib import Path
-from zntrack.utils import is_jsonable, serializer, deserializer
+from zntrack.utils import is_jsonable, serializer, deserializer, config
 from zntrack.utils.types import ZnTrackType, ZnTrackStage
 
 from typing import TYPE_CHECKING
@@ -169,6 +169,9 @@ class ZnTrackParent(ZnTrackType):
         """
         self.update_dvc()
         self.save_internals()
+
+        if config.no_dvc:
+            return
 
         self.write_dvc(force, exec_, always_changed, slurm, silent)
 

--- a/zntrack/utils/config.py
+++ b/zntrack/utils/config.py
@@ -24,11 +24,14 @@ class Config:
         Name of the JupyterNotebook, if the Nodes are defined in a Notebook
     nb_class_path: Path
         The path where jupyter notebooks should write the *.py
+    no_dvc: bool, default = False
+        Do not write a dvc file when true.
     """
 
     debug: bool = False  # not implemented yet
     nb_name: str = None
     nb_class_path: Path = Path("src")
+    no_dvc: bool = False
 
 
 config = Config()


### PR DESCRIPTION
Add the possibility to not write a dvc file after the `__call__`.
This can be useful, e.g. for tests