### PR TITLE
Add `MyNode.load` classmethod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ venv
 /build/
 /dist/
 /py_track.egg-info/
+__pychache__/

--- a/zntrack/__init__.py
+++ b/zntrack/__init__.py
@@ -14,14 +14,13 @@ import sys
 
 import znjson
 
-import zntrack.dvc
-
-from .core.decorator import Node
-from .dvc import DVC
-from .interface import DVCInterface
-from .project import ZnTrackProject
-from .utils import config
-from .utils.serializer import ZnTrackStageConverter, ZnTrackTypeConverter
+from zntrack.core.decorator import Node
+from zntrack.dvc import DVC
+from zntrack.interface import DVCInterface
+from zntrack.project import ZnTrackProject
+from zntrack.utils import config
+from zntrack.utils.serializer import ZnTrackStageConverter, ZnTrackTypeConverter
+from zntrack.utils.type_hints import TypeHintParent
 
 # register converters
 znjson.config.ACTIVE_CONVERTER = [
@@ -35,7 +34,15 @@ except AttributeError:
     pass
 
 #
-__all__ = ["Node", "ZnTrackProject", "DVCInterface", "DVC", "config", "dvc"]
+__all__ = [
+    "Node",
+    "ZnTrackProject",
+    "DVCInterface",
+    "DVC",
+    "config",
+    "dvc",
+    "TypeHintParent",
+]
 
 __version__ = "0.2.0"
 

--- a/zntrack/utils/type_hints.py
+++ b/zntrack/utils/type_hints.py
@@ -26,3 +26,9 @@ class TypeHintParent(ABC):
     def run(self):
         """Run method to be called by DVC"""
         pass
+
+    @classmethod
+    def load(cls, name=None):
+        if name is None:
+            return cls(load=True)
+        return cls(load=True, name=name)


### PR DESCRIPTION
In addition to `MyNode(load=True)` the prefered method will be `MyNode.load(name=<...>)` which can be inherited from `TypeHintParent`

# TODOs
- [ ] Tests
- [ ] rename `TypeHintParent`
- [ ] update docs
- [ ] `MyNode.load(name, rev=<..>)` Allow for revision or experiment name or so to be loaded from! This could break `dvc.deps`