### PR TITLE
add run argument in addition to `no_exec`

### DIFF
--- a/tests/integration_tests/test_single_node.py
+++ b/tests/integration_tests/test_single_node.py
@@ -81,6 +81,22 @@ def test_run(proj_path):
     assert load_test_node_1.outputs == "Lorem Ipsum"
 
 
+def test_run_no_exec(proj_path):
+    test_node_1 = ExampleNode01(inputs="Lorem Ipsum")
+    test_node_1.write_graph(no_exec=False)
+
+    load_test_node_1 = ExampleNode01.load()
+    assert load_test_node_1.outputs == "Lorem Ipsum"
+
+
+def test_run_exec(proj_path):
+    test_node_1 = ExampleNode01(inputs="Lorem Ipsum")
+    test_node_1.write_graph(run=True)
+
+    load_test_node_1 = ExampleNode01.load()
+    assert load_test_node_1.outputs == "Lorem Ipsum"
+
+
 def test_datacls_method(proj_path):
     example = ExampleNodeWithDataClsMethod(method=ExampleDataClsMethod(10, 20))
     example.write_graph()

--- a/zntrack/core/dvcgraph.py
+++ b/zntrack/core/dvcgraph.py
@@ -249,6 +249,7 @@ class GraphWriter:
         force: bool = True,
         no_run_cache: bool = False,
         dry_run: bool = False,
+        run: bool = None,
     ):
         """Write the DVC file using run.
 
@@ -266,6 +267,7 @@ class GraphWriter:
         external: dvc parameter
         always_changed: dvc parameter
         no_exec: dvc parameter
+        run: bool, inverse of no_exec. Will overwrite no_exec if set.
         force: dvc parameter
         no_run_cache: dvc parameter
         dry_run: bool, default = False
@@ -277,6 +279,8 @@ class GraphWriter:
         Use 'dvc status' to check, if the stage needs to be rerun.
 
         """
+        if run is not None:
+            no_exec = not run
 
         if nb_name is None:
             nb_name = config.nb_name


### PR DESCRIPTION
In addition to `write_graph(no_exec=False)` it is now possible to use `write_graph(run=True)`.
Because `exec` is a Python built-in it was replaced by `run`.