### PR TITLE
Support Python 3.7

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -18,6 +18,8 @@ jobs:
           - "3.10"
           - 3.9
           - 3.8
+          - 3.7
+          - 3.6
         os:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -19,7 +19,6 @@ jobs:
           - 3.9
           - 3.8
           - 3.7
-          - 3.6
         os:
           - ubuntu-latest
           - windows-latest

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setuptools.setup(
         "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=required_packages,
 )

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setuptools.setup(
         "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.6",
     install_requires=required_packages,
 )

--- a/tests/integration_tests/interface/test_base_interface.py
+++ b/tests/integration_tests/interface/test_base_interface.py
@@ -23,8 +23,8 @@ class HelloWorld(Node):
     outputs = zn.outs()
     inputs = dvc.params()
 
-    def __init__(self, inputs=None, name=None):
-        super(HelloWorld, self).__init__(name=name)
+    def __init__(self, inputs=None, **kwargs):
+        super(HelloWorld, self).__init__(**kwargs)
         self.inputs = inputs
 
     def run(self):

--- a/zntrack/interface/base.py
+++ b/zntrack/interface/base.py
@@ -113,17 +113,18 @@ class DVCInterface:
 
         for experiment in exp_list:
             for file in files:
+                file = pathlib.Path(file)
                 out_path = path / experiment.name
                 out_path.mkdir(parents=True, exist_ok=True)
                 cmd = [
                     "dvc",
                     "get",
                     ".",
-                    pathlib.Path(file).as_posix(),
+                    file.as_posix(),
                     "--rev",
                     experiment.hash,
                     "--out",
-                    out_path,
+                    out_path.as_posix(),
                 ]
                 log.debug(f"DVC command: {cmd}")
                 subprocess.run(cmd)

--- a/zntrack/interface/base.py
+++ b/zntrack/interface/base.py
@@ -12,6 +12,7 @@ import copy
 import dataclasses
 import json
 import logging
+import pathlib
 import subprocess
 from pathlib import Path
 from typing import List
@@ -118,7 +119,7 @@ class DVCInterface:
                     "dvc",
                     "get",
                     ".",
-                    file,
+                    pathlib.Path(file).as_posix(),
                     "--rev",
                     experiment.hash,
                     "--out",


### PR DESCRIPTION
This PR shows the issues with Python 3.7 and 3.6 in the test runs.

I will try to fix the issues for the windows CI and make ZnTrack compatible with Python 3.7.
Since Python 3.6 reached its end of life it will not be supported.