### PR TITLE
Stop converting jupyter to python after class definition is found

### DIFF
--- a/zntrack/core/jupyter.py
+++ b/zntrack/core/jupyter.py
@@ -28,7 +28,7 @@ def jupyter_class_to_file(silent, nb_name, module_name):
     )
 
     reading_class = False
-    found_class = False
+    found_node = False
 
     imports = ""
 
@@ -54,9 +54,11 @@ def jupyter_class_to_file(silent, nb_name, module_name):
             if line.startswith("@"):  # handle decorators
                 reading_class = True
                 class_definition += line
-            if line.startswith(f"class {module_name}"):
-                found_class = True
-            if found_class and not reading_class:
+            if line.startswith(f"class {module_name}") or line.startswith(
+                f"def {module_name}"
+            ):
+                found_node = True
+            if found_node and not reading_class:
                 break
 
     src = imports + "\n\n" + class_definition

--- a/zntrack/core/jupyter.py
+++ b/zntrack/core/jupyter.py
@@ -10,6 +10,7 @@ from zntrack.utils.config import config
 
 def jupyter_class_to_file(silent, nb_name, module_name):
     """Extract the class definition form an ipynb file"""
+    # TOOD is it really module_name and not class name?
 
     if not silent:
         log.warning(
@@ -27,6 +28,7 @@ def jupyter_class_to_file(silent, nb_name, module_name):
     )
 
     reading_class = False
+    found_class = False
 
     imports = ""
 
@@ -52,6 +54,10 @@ def jupyter_class_to_file(silent, nb_name, module_name):
             if line.startswith("@"):  # handle decorators
                 reading_class = True
                 class_definition += line
+            if line.startswith(f"class {module_name}"):
+                found_class = True
+            if found_class and not reading_class:
+                break
 
     src = imports + "\n\n" + class_definition
 

--- a/zntrack/core/jupyter.py
+++ b/zntrack/core/jupyter.py
@@ -59,7 +59,10 @@ def jupyter_class_to_file(silent, nb_name, module_name):
             ):
                 found_node = True
             if found_node and not reading_class:
-                break
+                if re.match(r"#.*zntrack:.*break", line):
+                    # stop converting the file after this line if the Node was already
+                    #  found
+                    break
 
     src = imports + "\n\n" + class_definition
 


### PR DESCRIPTION
Currently the full notebook is converted into a `*.py` file.
With this change you can add `# zntrack: break` to stop converting the Notebook into a `*.py` file, if the Node that the conversion triggered was already found.