### PR TITLE
Allow for class dependencies

### DIFF
--- a/examples/docs/03_dependencies.ipynb
+++ b/examples/docs/03_dependencies.ipynb
@@ -261,7 +261,8 @@
     "dependency: Path = dvc.deps([Path('some_file.txt'), 'some_other_file.txt'])\n",
     "```\n",
     "\n",
-    "If there are now arguments to `load` we can also use `dvc.deps(RandomNumber)` instead of `dvc.deps(RandomNumber.load())`. This should not be used with attributes such as  `dvc.deps(RandomNumber.file)`, because the file name could change and this would not be recognized. In general, for Node dependecies the full Node should be passed and not some Node attributes to avoid potentially unwanted behaviour."
+    "If there are no arguments to `load` we can also use `dvc.deps(RandomNumber)` instead of `dvc.deps(RandomNumber.load())`. This should not be used with attributes such as  `dvc.deps(RandomNumber.file)`, because the file name could change and this would not be recognized. In general, for Node dependencies the full Node should be passed and not some Node attributes to avoid potentially unwanted behaviour.\n",
+    "A clear benefit of passing `RandomNumber` without `load` is the evaluation of the class happens upon the instantiation and not during the definition of the class."
    ]
   },
   {

--- a/examples/docs/03_dependencies.ipynb
+++ b/examples/docs/03_dependencies.ipynb
@@ -74,7 +74,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Initialized empty Git repository in C:/Users/fabia/AppData/Local/Temp/tmpb76jker8/.git/\n",
+      "Initialized empty Git repository in C:/Users/fabia/AppData/Local/Temp/tmpy4v49p74/.git/\n",
       "Initialized DVC repository.\n",
       "\n",
       "You can now commit the changes to git.\n",
@@ -152,14 +152,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2022-01-13 20:27:05,229 (WARNING): Jupyter support is an experimental feature! Please save your notebook before running this command!\n",
+      "2022-02-18 09:54:46,088 dvcgraph (WARNING): --- Writing new DVC file! ---\n",
+      "2022-02-18 09:54:46,089 jupyter (WARNING): Jupyter support is an experimental feature! Please save your notebook before running this command!\n",
       "Submit issues to https://github.com/zincware/ZnTrack.\n",
-      "2022-01-13 20:27:05,230 (WARNING): Converting 03_dependencies.ipynb to file RandomNumber.py\n",
-      "2022-01-13 20:27:07,718 (WARNING): --- Writing new DVC file! ---\n",
-      "2022-01-13 20:27:09,167 (WARNING): Jupyter support is an experimental feature! Please save your notebook before running this command!\n",
+      "2022-02-18 09:54:46,089 jupyter (WARNING): Converting 03_dependencies.ipynb to file RandomNumber.py\n",
+      "2022-02-18 09:54:50,092 utils (INFO): Creating 'dvc.yaml'\r\n",
+      "Adding stage 'RandomNumber' in 'dvc.yaml'\r\n",
+      "\r\n",
+      "To track the changes with git, run:\r\n",
+      "\r\n",
+      "    git add dvc.yaml 'nodes\\RandomNumber\\.gitignore'\r\n",
+      "\r\n",
+      "To enable auto staging, run:\r\n",
+      "\r\n",
+      "\tdvc config core.autostage true\r\n",
+      "\n",
+      "2022-02-18 09:54:50,097 dvcgraph (WARNING): --- Writing new DVC file! ---\n",
+      "2022-02-18 09:54:50,098 jupyter (WARNING): Jupyter support is an experimental feature! Please save your notebook before running this command!\n",
       "Submit issues to https://github.com/zincware/ZnTrack.\n",
-      "2022-01-13 20:27:09,167 (WARNING): Converting 03_dependencies.ipynb to file ComputePower.py\n",
-      "2022-01-13 20:27:11,817 (WARNING): --- Writing new DVC file! ---\n"
+      "2022-02-18 09:54:50,098 jupyter (WARNING): Converting 03_dependencies.ipynb to file ComputePower.py\n",
+      "2022-02-18 09:54:54,100 utils (INFO): Adding stage 'ComputePower' in 'dvc.yaml'\r\n",
+      "\r\n",
+      "To track the changes with git, run:\r\n",
+      "\r\n",
+      "    git add 'nodes\\ComputePower\\.gitignore' dvc.yaml\r\n",
+      "\r\n",
+      "To enable auto staging, run:\r\n",
+      "\r\n",
+      "\tdvc config core.autostage true\r\n",
+      "\n"
      ]
     }
    ],
@@ -189,7 +210,11 @@
       "\n",
       "To track the changes with git, run:\n",
       "\n",
-      "\tgit add dvc.lock\n",
+      "    git add dvc.lock\n",
+      "\n",
+      "To enable auto staging, run:\n",
+      "\n",
+      "\tdvc config core.autostage true\n",
       "Use `dvc push` to send your updates to remote storage.\n"
      ]
     }
@@ -208,7 +233,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "12.0 ^ 2.0 = 144.0\n"
+      "9.0 ^ 2.0 = 81.0\n"
      ]
     }
    ],
@@ -234,7 +259,9 @@
     "As every  `dvc.<...>` it also supports lists.\n",
     "```py\n",
     "dependency: Path = dvc.deps([Path('some_file.txt'), 'some_other_file.txt'])\n",
-    "```"
+    "```\n",
+    "\n",
+    "If there are now arguments to `load` we can also use `dvc.deps(RandomNumber)` instead of `dvc.deps(RandomNumber.load())`. This should not be used with attributes such as  `dvc.deps(RandomNumber.file)`, because the file name could change and this would not be recognized. In general, for Node dependecies the full Node should be passed and not some Node attributes to avoid potentially unwanted behaviour."
    ]
   },
   {
@@ -245,7 +272,7 @@
    "outputs": [],
    "source": [
     "class WriteToFile(Node):\n",
-    "    random_number: RandomNumber = dvc.deps(RandomNumber.load())\n",
+    "    random_number: RandomNumber = dvc.deps(RandomNumber)\n",
     "    file: Path = dvc.outs(Path(\"random_number.txt\"))\n",
     "\n",
     "    def run(self):\n",
@@ -253,7 +280,7 @@
     "\n",
     "\n",
     "class PowerFromFile(Node):\n",
-    "    file: Path = dvc.deps(WriteToFile.load().file)\n",
+    "    file: Path = dvc.deps(WriteToFile.load().file) # try to avoid this\n",
     "    number = zn.outs()\n",
     "    power = zn.params(2)\n",
     "\n",
@@ -263,7 +290,8 @@
     "\n",
     "\n",
     "class ComparePowers(Node):\n",
-    "    power_deps = dvc.deps([PowerFromFile.load(), ComputePower.load()])\n",
+    "    # both are possible, ComputePower or ComputePower.load()\n",
+    "    power_deps = dvc.deps([PowerFromFile.load(), ComputePower])\n",
     "\n",
     "    def run(self):\n",
     "        assert self.power_deps[0].number == self.power_deps[1].number"
@@ -279,18 +307,48 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2022-01-13 20:27:17,779 (WARNING): Jupyter support is an experimental feature! Please save your notebook before running this command!\n",
+      "2022-02-18 09:54:58,136 dvcgraph (WARNING): --- Writing new DVC file! ---\n",
+      "2022-02-18 09:54:58,137 jupyter (WARNING): Jupyter support is an experimental feature! Please save your notebook before running this command!\n",
       "Submit issues to https://github.com/zincware/ZnTrack.\n",
-      "2022-01-13 20:27:17,779 (WARNING): Converting 03_dependencies.ipynb to file WriteToFile.py\n",
-      "2022-01-13 20:27:20,119 (WARNING): --- Writing new DVC file! ---\n",
-      "2022-01-13 20:27:21,703 (WARNING): Jupyter support is an experimental feature! Please save your notebook before running this command!\n",
+      "2022-02-18 09:54:58,137 jupyter (WARNING): Converting 03_dependencies.ipynb to file WriteToFile.py\n",
+      "2022-02-18 09:55:02,285 utils (INFO): Adding stage 'WriteToFile' in 'dvc.yaml'\r\n",
+      "\r\n",
+      "To track the changes with git, run:\r\n",
+      "\r\n",
+      "    git add .gitignore dvc.yaml\r\n",
+      "\r\n",
+      "To enable auto staging, run:\r\n",
+      "\r\n",
+      "\tdvc config core.autostage true\r\n",
+      "\n",
+      "2022-02-18 09:55:02,286 dvcgraph (WARNING): --- Writing new DVC file! ---\n",
+      "2022-02-18 09:55:02,287 jupyter (WARNING): Jupyter support is an experimental feature! Please save your notebook before running this command!\n",
       "Submit issues to https://github.com/zincware/ZnTrack.\n",
-      "2022-01-13 20:27:21,704 (WARNING): Converting 03_dependencies.ipynb to file PowerFromFile.py\n",
-      "2022-01-13 20:27:24,058 (WARNING): --- Writing new DVC file! ---\n",
-      "2022-01-13 20:27:25,580 (WARNING): Jupyter support is an experimental feature! Please save your notebook before running this command!\n",
+      "2022-02-18 09:55:02,287 jupyter (WARNING): Converting 03_dependencies.ipynb to file PowerFromFile.py\n",
+      "2022-02-18 09:55:06,256 utils (INFO): Adding stage 'PowerFromFile' in 'dvc.yaml'\r\n",
+      "\r\n",
+      "To track the changes with git, run:\r\n",
+      "\r\n",
+      "    git add 'nodes\\PowerFromFile\\.gitignore' dvc.yaml\r\n",
+      "\r\n",
+      "To enable auto staging, run:\r\n",
+      "\r\n",
+      "\tdvc config core.autostage true\r\n",
+      "\n",
+      "2022-02-18 09:55:06,269 dvcgraph (WARNING): --- Writing new DVC file! ---\n",
+      "2022-02-18 09:55:06,270 jupyter (WARNING): Jupyter support is an experimental feature! Please save your notebook before running this command!\n",
       "Submit issues to https://github.com/zincware/ZnTrack.\n",
-      "2022-01-13 20:27:25,581 (WARNING): Converting 03_dependencies.ipynb to file ComparePowers.py\n",
-      "2022-01-13 20:27:28,032 (WARNING): --- Writing new DVC file! ---\n"
+      "2022-02-18 09:55:06,270 jupyter (WARNING): Converting 03_dependencies.ipynb to file ComparePowers.py\n",
+      "2022-02-18 09:55:10,128 utils (INFO): Adding stage 'ComparePowers' in 'dvc.yaml'\r\n",
+      "\r\n",
+      "To track the changes with git, run:\r\n",
+      "\r\n",
+      "    git add dvc.yaml\r\n",
+      "\r\n",
+      "To enable auto staging, run:\r\n",
+      "\r\n",
+      "\tdvc config core.autostage true\r\n",
+      "\n"
      ]
     }
    ],
@@ -364,7 +422,11 @@
       "\n",
       "To track the changes with git, run:\n",
       "\n",
-      "\tgit add dvc.lock\n",
+      "    git add dvc.lock\n",
+      "\n",
+      "To enable auto staging, run:\n",
+      "\n",
+      "\tdvc config core.autostage true\n",
       "Use `dvc push` to send your updates to remote storage.\n"
      ]
     }
@@ -404,7 +466,7 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "stages:\n  RandomNumber:\n    cmd: \"python -c \\\"from src.RandomNumber import RandomNumber; RandomNumber.load(name='RandomNumber').run_and_save()\\\"\\\n      \\ \"\n    deps:\n    - src/RandomNumber.py\n    params:\n    - RandomNumber\n    outs:\n    - nodes\\RandomNumber\\outs.json\n  ComputePower:\n    cmd: \"python -c \\\"from src.ComputePower import ComputePower; ComputePower.load(name='ComputePower').run_and_save()\\\"\\\n      \\ \"\n    deps:\n    - nodes\\RandomNumber\\outs.json\n    - src/ComputePower.py\n    params:\n    - ComputePower\n    outs:\n    - nodes\\ComputePower\\outs.json\n  WriteToFile:\n    cmd: \"python -c \\\"from src.WriteToFile import WriteToFile; WriteToFile.load(name='WriteToFile').run_and_save()\\\"\\\n      \\ \"\n    deps:\n    - nodes\\RandomNumber\\outs.json\n    - src/WriteToFile.py\n    outs:\n    - random_number.txt\n  PowerFromFile:\n    cmd: \"python -c \\\"from src.PowerFromFile import PowerFromFile; PowerFromFile.load(name='PowerFromFile').run_and_save()\\\"\\\n      \\ \"\n    deps:\n    - random_number.txt\n    - src/PowerFromFile.py\n    params:\n    - PowerFromFile\n    outs:\n    - nodes\\PowerFromFile\\outs.json\n  ComparePowers:\n    cmd: \"python -c \\\"from src.ComparePowers import ComparePowers; ComparePowers.load(name='ComparePowers').run_and_save()\\\"\\\n      \\ \"\n    deps:\n    - nodes\\ComputePower\\outs.json\n    - nodes\\PowerFromFile\\outs.json\n    - src/ComparePowers.py\n"
+      "text/plain": "stages:\n  RandomNumber:\n    cmd: \"python -c \\\"from src.RandomNumber import RandomNumber; RandomNumber.load(name='RandomNumber').run_and_save()\\\"\\\n      \\ \"\n    deps:\n    - src/RandomNumber.py\n    params:\n    - RandomNumber\n    outs:\n    - nodes/RandomNumber/outs.json\n  ComputePower:\n    cmd: \"python -c \\\"from src.ComputePower import ComputePower; ComputePower.load(name='ComputePower').run_and_save()\\\"\\\n      \\ \"\n    deps:\n    - nodes/RandomNumber/outs.json\n    - src/ComputePower.py\n    params:\n    - ComputePower\n    outs:\n    - nodes/ComputePower/outs.json\n  WriteToFile:\n    cmd: \"python -c \\\"from src.WriteToFile import WriteToFile; WriteToFile.load(name='WriteToFile').run_and_save()\\\"\\\n      \\ \"\n    deps:\n    - nodes/RandomNumber/outs.json\n    - src/WriteToFile.py\n    outs:\n    - random_number.txt\n  PowerFromFile:\n    cmd: \"python -c \\\"from src.PowerFromFile import PowerFromFile; PowerFromFile.load(name='PowerFromFile').run_and_save()\\\"\\\n      \\ \"\n    deps:\n    - random_number.txt\n    - src/PowerFromFile.py\n    params:\n    - PowerFromFile\n    outs:\n    - nodes/PowerFromFile/outs.json\n  ComparePowers:\n    cmd: \"python -c \\\"from src.ComparePowers import ComparePowers; ComparePowers.load(name='ComparePowers').run_and_save()\\\"\\\n      \\ \"\n    deps:\n    - nodes/ComputePower/outs.json\n    - nodes/PowerFromFile/outs.json\n    - src/ComparePowers.py\n"
      },
      "metadata": {},
      "output_type": "display_data"

--- a/tests/integration_tests/test_node_to_node_dependencies.py
+++ b/tests/integration_tests/test_node_to_node_dependencies.py
@@ -88,6 +88,18 @@ def test_dvc_outs(proj_path):
     )
 
 
+def test_dvc_outs_no_load(proj_path):
+    DVCOuts().write_graph()
+    assert issubclass(DVCOuts, Node)
+    DependenciesCollector(dependencies=DVCOuts).write_graph()
+
+    subprocess.check_call(["dvc", "repro"])
+
+    assert (
+        DependenciesCollector.load().dependencies.data_file.read_text() == "Lorem Ipsum"
+    )
+
+
 def test_dvc_reversed(proj_path):
     """Create the instances first and at the end call write_graph"""
 

--- a/tests/unit_tests/core/test_core_base.py
+++ b/tests/unit_tests/core/test_core_base.py
@@ -1,12 +1,12 @@
 import json
 import pathlib
-from unittest.mock import call, mock_open, patch
+from unittest.mock import MagicMock, call, mock_open, patch
 
 import pytest
 import yaml
 
 from zntrack import dvc, zn
-from zntrack.core.base import Node
+from zntrack.core.base import Node, update_dependency_options
 
 
 class ExampleDVCOutsNode(Node):
@@ -169,3 +169,20 @@ def test_WrongInit():
     """Test that a TypeError occurs if any value it not set to default in __init__"""
     with pytest.raises(TypeError):
         WrongInit.load()
+
+
+def test_update_dependency_options():
+    """Test update_dependency_options calls
+
+    I'm not sure if this is the supposed way to use patch / MagicMock but it works
+    """
+
+    with patch(f"{__name__}.MagicMock", spec=Node):
+        magic_mock = MagicMock()
+        update_dependency_options(magic_mock)
+        assert magic_mock.update_options.called
+
+    with patch(f"{__name__}.MagicMock", spec=Node):
+        magic_mock = MagicMock()
+        update_dependency_options([magic_mock])
+        assert magic_mock.update_options.called

--- a/zntrack/core/base.py
+++ b/zntrack/core/base.py
@@ -20,6 +20,19 @@ from zntrack.zn import params
 log = logging.getLogger(__name__)
 
 
+def update_dependency_options(value):
+    """Handle Node dependencies
+
+    The default value is created upton instantiation of a ZnTrackOption,
+    if a new class is created via Instance.load() it does not automatically load
+    the default_value Nodes, so we must to this manually here and call update_options.
+    """
+    if isinstance(value, (list, tuple)):
+        [update_dependency_options(x) for x in value]
+    if isinstance(value, Node):
+        value.update_options()
+
+
 class Node(GraphWriter):
     """Main parent class for all ZnTrack Node
 
@@ -35,8 +48,11 @@ class Node(GraphWriter):
     is_loaded: bool = False
 
     def __init__(self, **kwargs):
-        self.is_loaded = kwargs.pop("is_loaded", False)
         super().__init__(**kwargs)
+        self.is_loaded = kwargs.pop("is_loaded", False)
+        for data in self._descriptor_list:
+            if data.zntrack_type == utils.ZnTypes.deps:
+                update_dependency_options(data.default_value)
 
     @utils.deprecated(
         reason=(
@@ -60,7 +76,6 @@ class Node(GraphWriter):
         zn_option_fields, sig_params = [], []
         for name, item in cls.__dict__.items():
             if isinstance(item, params):
-
                 # For the new __init__
                 zn_option_fields.append(name)
 

--- a/zntrack/core/dvcgraph.py
+++ b/zntrack/core/dvcgraph.py
@@ -39,7 +39,7 @@ def handle_deps(value) -> list:
         elif value is None:
             pass
         else:
-            raise ValueError(f"Type {type(value)} is not supported!")
+            raise ValueError(f"Type {type(value)} ({value}) is not supported!")
 
     return script
 
@@ -150,9 +150,6 @@ class GraphWriter:
 
     def __init__(self, **kwargs):
         self.node_name = kwargs.get("name", None)
-        for data in self._descriptor_list:
-            if data.zntrack_type == utils.ZnTypes.deps:
-                data.update_default()
 
     @property
     def _descriptor_list(self) -> typing.List[ZnTrackOption]:

--- a/zntrack/core/zntrackoption.py
+++ b/zntrack/core/zntrackoption.py
@@ -88,28 +88,6 @@ class ZnTrackOption(descriptor.Descriptor):
     def __str__(self):
         return f"{self.dvc_option} / {self.name}"
 
-    def update_default(self):
-        """Update default_value
-
-        The default value is created upton instantiation of this descriptor,
-        if a new class is created via Instance.load() it does not automatically load
-        the default_value Nodes, so we must to this manually here
-        """
-        if isinstance(self.default_value, (list, tuple)):
-            for value in self.default_value:
-                # cheap trick because circular imports - TODO find clever fix!
-                try:
-                    value.update_options()
-                except AttributeError:
-                    # value is not a Node instance
-                    pass
-        else:
-            try:
-                self.default_value.update_options()
-            except AttributeError:
-                # default_value is not a Node instance
-                pass
-
     def get_filename(self, instance) -> pathlib.Path:
         """Get the name of the file this ZnTrackOption will save its values to"""
         if uses_node_name(self.zntrack_type, instance) is None:

--- a/zntrack/dvc/__init__.py
+++ b/zntrack/dvc/__init__.py
@@ -56,6 +56,13 @@ class deps(ZnTrackOption):
     zntrack_type = utils.ZnTypes.deps
     file = utils.Files.zntrack
 
+    def __get__(self, instance, owner):
+        """Use load_node_dependency before returning the value"""
+        value = super(deps, self).__get__(instance, owner)
+        value = utils.utils.load_node_dependency(value, log_warning=True)
+        setattr(instance, self.name, value)
+        return value
+
 
 class outs(ZnTrackOption):
     """Identify DVC option

--- a/zntrack/zn/__init__.py
+++ b/zntrack/zn/__init__.py
@@ -61,6 +61,13 @@ class deps(ZnTrackOption):
     zntrack_type = utils.ZnTypes.deps
     file = utils.Files.zntrack
 
+    def __get__(self, instance, owner):
+        """Use load_node_dependency before returning the value"""
+        value = super(deps, self).__get__(instance, owner)
+        value = utils.utils.load_node_dependency(value)
+        setattr(instance, self.name, value)
+        return value
+
 
 class metrics(ZnTrackOption):
     """Identify DVC option


### PR DESCRIPTION
To avoid loading a class as da dependency it is now possible to use

```py
deps = zn.deps(SomeNode)
# or
deps = zn.deps(SomeNode.load())
```

This avoids loading `SomeNode` upon class definition and only load the class in the `__init__`. It does not work with `load(name=...)` or `load(lazy=...)`.