### PR TITLE
Allow `Node[<nodename>]` to load a Node

### DIFF
--- a/tests/integration_tests/test_single_node.py
+++ b/tests/integration_tests/test_single_node.py
@@ -296,3 +296,15 @@ class OutsNotWritten(Node):
 def test_OutsNotWritten(proj_path):
     with pytest.raises(DVCProcessError):
         OutsNotWritten().write_graph(run=True)
+
+
+def test_load_named_nodes(proj_path):
+    ExampleNode01(name="Node01", inputs=42).write_graph(run=True)
+    ExampleNode01(name="Node02", inputs=3.1415).write_graph(run=True)
+
+    assert ExampleNode01["Node01"].outputs == 42
+    assert ExampleNode01["Node02"].outputs == 3.1415
+
+    # this will run load with name=Node01, lazy=True/False
+    assert ExampleNode01[("Node01", True)].outputs == 42
+    assert ExampleNode01[("Node01", False)].outputs == 42

--- a/tests/integration_tests/test_single_node.py
+++ b/tests/integration_tests/test_single_node.py
@@ -308,3 +308,7 @@ def test_load_named_nodes(proj_path):
     # this will run load with name=Node01, lazy=True/False
     assert ExampleNode01[("Node01", True)].outputs == 42
     assert ExampleNode01[("Node01", False)].outputs == 42
+
+    # this will run load with name=Node01, lazy=True/False
+    assert ExampleNode01[{"name": "Node01", "lazy": True}].outputs == 42
+    assert ExampleNode01[{"name": "Node01", "lazy": False}].outputs == 42

--- a/zntrack/core/base.py
+++ b/zntrack/core/base.py
@@ -61,9 +61,20 @@ class LoadViaGetItem(type):
     """Metaclass for adding getitem support to load"""
 
     def __getitem__(self: Node, item) -> Node:
-        """Allow Node[<nodename>] to access an instance of the Node"""
+        """Allow Node[<nodename>] to access an instance of the Node
+
+        Attributes
+        ----------
+        item: str|tuple|dict
+            Can be a string, for load(name=item)
+            Can be a tuple for load(*item) | e.g. ("nodename", True)
+            Can be a dict for load(**item) | e.g. {name:"nodename", lazy:True}
+
+        """
         if isinstance(item, tuple):
             return self.load(*item)
+        elif isinstance(item, dict):
+            return self.load(**item)
         return self.load(name=item)
 
 

--- a/zntrack/core/base.py
+++ b/zntrack/core/base.py
@@ -57,7 +57,17 @@ def update_dependency_options(value):
         value.update_options()
 
 
-class Node(GraphWriter):
+class LoadViaGetItem(type):
+    """Metaclass for adding getitem support to load"""
+
+    def __getitem__(self: Node, item) -> Node:
+        """Allow Node[<nodename>] to access an instance of the Node"""
+        if isinstance(item, tuple):
+            return self.load(*item)
+        return self.load(name=item)
+
+
+class Node(GraphWriter, metaclass=LoadViaGetItem):
     """Main parent class for all ZnTrack Node
 
     The methods implemented in this class are primarily loading and saving parameters.

--- a/zntrack/utils/utils.py
+++ b/zntrack/utils/utils.py
@@ -202,6 +202,8 @@ def get_python_interpreter() -> str:
 
         except subprocess.CalledProcessError:
             log.debug(f"{interpreter} is not working!")
+        except FileNotFoundError as err:
+            log.debug(err)
     raise ValueError(
         "Could not find a working python interpreter to work with subprocesses!"
     )


### PR DESCRIPTION
This PR introduces an additonal syntex to load a Node via:

```py
class MyNode(Node):
   pass

my_node = MyNode["nodename"]
# it also supports args / kwargs
my_node = MyNode[{"name": "nodename"}]
```