### PR TITLE
Allow for Node Attribute dependencies

### DIFF
--- a/examples/docs/01_Intro.ipynb
+++ b/examples/docs/01_Intro.ipynb
@@ -81,20 +81,20 @@
       "\n",
       "You can now commit the changes to git.\n",
       "\n",
-      "\u001B[31m+---------------------------------------------------------------------+\n",
-      "\u001B[0m\u001B[31m|\u001B[0m                                                                     \u001B[31m|\u001B[0m\n",
-      "\u001B[31m|\u001B[0m        DVC has enabled anonymous aggregate usage analytics.         \u001B[31m|\u001B[0m\n",
-      "\u001B[31m|\u001B[0m     Read the analytics documentation (and how to opt-out) here:     \u001B[31m|\u001B[0m\n",
-      "\u001B[31m|\u001B[0m             <\u001B[36mhttps://dvc.org/doc/user-guide/analytics\u001B[39m>              \u001B[31m|\u001B[0m\n",
-      "\u001B[31m|\u001B[0m                                                                     \u001B[31m|\u001B[0m\n",
-      "\u001B[31m+---------------------------------------------------------------------+\n",
-      "\u001B[0m\n",
-      "\u001B[33mWhat's next?\u001B[39m\n",
-      "\u001B[33m------------\u001B[39m\n",
-      "- Check out the documentation: <\u001B[36mhttps://dvc.org/doc\u001B[39m>\n",
-      "- Get help and share ideas: <\u001B[36mhttps://dvc.org/chat\u001B[39m>\n",
-      "- Star us on GitHub: <\u001B[36mhttps://github.com/iterative/dvc\u001B[39m>\n",
-      "\u001B[0m"
+      "\u001b[31m+---------------------------------------------------------------------+\n",
+      "\u001b[0m\u001b[31m|\u001b[0m                                                                     \u001b[31m|\u001b[0m\n",
+      "\u001b[31m|\u001b[0m        DVC has enabled anonymous aggregate usage analytics.         \u001b[31m|\u001b[0m\n",
+      "\u001b[31m|\u001b[0m     Read the analytics documentation (and how to opt-out) here:     \u001b[31m|\u001b[0m\n",
+      "\u001b[31m|\u001b[0m             <\u001b[36mhttps://dvc.org/doc/user-guide/analytics\u001b[39m>              \u001b[31m|\u001b[0m\n",
+      "\u001b[31m|\u001b[0m                                                                     \u001b[31m|\u001b[0m\n",
+      "\u001b[31m+---------------------------------------------------------------------+\n",
+      "\u001b[0m\n",
+      "\u001b[33mWhat's next?\u001b[39m\n",
+      "\u001b[33m------------\u001b[39m\n",
+      "- Check out the documentation: <\u001b[36mhttps://dvc.org/doc\u001b[39m>\n",
+      "- Get help and share ideas: <\u001b[36mhttps://dvc.org/chat\u001b[39m>\n",
+      "- Star us on GitHub: <\u001b[36mhttps://github.com/iterative/dvc\u001b[39m>\n",
+      "\u001b[0m"
      ]
     }
    ],
@@ -245,6 +245,7 @@
    "outputs": [],
    "source": [
     "import logging\n",
+    "\n",
     "config.log_level = logging.INFO"
    ]
   },

--- a/examples/docs/03_dependencies.ipynb
+++ b/examples/docs/03_dependencies.ipynb
@@ -15,9 +15,9 @@
     "## Node dependencies\n",
     "We will first look at Node based dependencies starting from a RandomNumber `Hello World` example.\n",
     "In our first stage we create a random number and then we add another Node that depends on this one.\n",
-    "We can do this very easily by setting the `dvc.deps` in the following way\n",
+    "We can do this very easily by setting the `zn.deps` in the following way\n",
     "```py\n",
-    "dependency: Stage = dvc.deps(Stage.load()\n",
+    "dependency: Stage = zn.deps(Stage) # or zn.deps(Stage.load())\n",
     "```\n",
     "\n",
     "This allows us to access all properties of the `dependency` attribute."
@@ -74,7 +74,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Initialized empty Git repository in /tmp/tmp1cphhnad/.git/\r\n",
+      "Initialized empty Git repository in /tmp/tmp6z7c4790/.git/\r\n",
       "Initialized DVC repository.\r\n",
       "\r\n",
       "You can now commit the changes to git.\r\n",
@@ -153,10 +153,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2022-02-22 13:37:09,358 (WARNING): Jupyter support is an experimental feature! Please save your notebook before running this command!\n",
+      "2022-03-16 13:42:38,692 (WARNING): Jupyter support is an experimental feature! Please save your notebook before running this command!\n",
       "Submit issues to https://github.com/zincware/ZnTrack.\n",
-      "2022-02-22 13:37:12,883 (WARNING): Running DVC command: 'dvc run -n RandomNumber ...'\n",
-      "2022-02-22 13:37:18,895 (WARNING): Running DVC command: 'dvc run -n ComputePower ...'\n"
+      "2022-03-16 13:42:42,495 (WARNING): Running DVC command: 'dvc run -n RandomNumber ...'\n",
+      "2022-03-16 13:42:49,268 (WARNING): Running DVC command: 'dvc run -n ComputePower ...'\n"
      ]
     }
    ],
@@ -210,7 +210,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "11.0 ^ 2.0 = 121.0\n"
+      "7.0 ^ 2.0 = 49.0\n"
      ]
     }
    ],
@@ -288,9 +288,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2022-02-22 13:37:28,604 (WARNING): Running DVC command: 'dvc run -n WriteToFile ...'\n",
-      "2022-02-22 13:37:34,666 (WARNING): Running DVC command: 'dvc run -n PowerFromFile ...'\n",
-      "2022-02-22 13:37:40,425 (WARNING): Running DVC command: 'dvc run -n ComparePowers ...'\n"
+      "2022-03-16 13:43:00,548 (WARNING): Running DVC command: 'dvc run -n WriteToFile ...'\n",
+      "2022-03-16 13:43:07,632 (WARNING): Running DVC command: 'dvc run -n PowerFromFile ...'\n",
+      "2022-03-16 13:43:14,835 (WARNING): Running DVC command: 'dvc run -n ComparePowers ...'\n"
      ]
     }
    ],
@@ -423,8 +423,133 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "## Node attributes as dependencies\n",
+    "\n",
+    "It is also possible to specify a Node attribute as a dependency. In this case you will be able to access the value of the attribute directly instead of using the Node class.\n",
+    "This can be used for all `dvc.<option>` and `zn.<option>` as well as e.g. class properties.\n",
+    "Note that the dvc dependencies will still be written for the full Node and won't be limited to the Node attribute.\n",
+    "To be able to define a dependency of an attribute the `zntrack.getdeps` function is required."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
    "cell_type": "code",
    "execution_count": 15,
+   "outputs": [],
+   "source": [
+    "from zntrack import getdeps"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "outputs": [],
+   "source": [
+    "class ComputePowerFromNumber(Node):\n",
+    "    number: float = zn.deps()  # this will be float instead of RandomNumber\n",
+    "\n",
+    "    power: int = zn.params()\n",
+    "    result: float = zn.outs()\n",
+    "\n",
+    "    def run(self):\n",
+    "        self.result = self.number**self.power"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-16 13:43:31,053 (WARNING): Running DVC command: 'dvc run -n ComputePowerFromNumber ...'\n"
+     ]
+    }
+   ],
+   "source": [
+    "ComputePowerFromNumber(number=getdeps(RandomNumber, \"number\"), power=2.0).write_graph(\n",
+    "    run=True\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "`getdeps(RandomNumber, \"number\")` can also be replaced by `getdeps(RandomNumber[\"nodename\"], \"number\")` or `getdeps(RandomNumber.load(name=\"nodename\"), \"number\")`.\n",
+    "The first argument represents the Node and the second argument is the attribute, similar to `getattr()`."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "outputs": [],
+   "source": [
+    "compute_power = ComputePowerFromNumber.load()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7.0 ^ 2.0 = 49.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"{compute_power.number} ^ {compute_power.power} = {compute_power.result}\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
    "id": "b26fb0f0-5f3e-40d0-b1fd-8d5844f051e8",
    "metadata": {
     "nbsphinx": "hidden",

--- a/examples/docs/06_named_nodes.ipynb
+++ b/examples/docs/06_named_nodes.ipynb
@@ -47,7 +47,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Initialized empty Git repository in /tmp/tmpptggw90x/.git/\r\n",
+      "Initialized empty Git repository in /tmp/tmpcn8yts4z/.git/\r\n",
       "Initialized DVC repository.\r\n",
       "\r\n",
       "You can now commit the changes to git.\r\n",
@@ -114,11 +114,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2022-02-22 13:52:00,589 (WARNING): Jupyter support is an experimental feature! Please save your notebook before running this command!\n",
+      "2022-03-16 13:28:59,293 (WARNING): Jupyter support is an experimental feature! Please save your notebook before running this command!\n",
       "Submit issues to https://github.com/zincware/ZnTrack.\n",
-      "2022-02-22 13:52:04,249 (WARNING): Running DVC command: 'dvc run -n HelloWorld ...'\n",
-      "2022-02-22 13:52:11,594 (WARNING): Running DVC command: 'dvc run -n Test01 ...'\n",
-      "2022-02-22 13:52:18,383 (WARNING): Running DVC command: 'dvc run -n Test02 ...'\n"
+      "2022-03-16 13:29:03,070 (WARNING): Running DVC command: 'dvc run -n HelloWorld ...'\n",
+      "2022-03-16 13:29:10,857 (WARNING): Running DVC command: 'dvc run -n Test01 ...'\n",
+      "2022-03-16 13:29:18,410 (WARNING): Running DVC command: 'dvc run -n Test02 ...'\n"
      ]
     }
    ],
@@ -198,7 +198,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2022-02-22 13:52:27,386 (WARNING): Running DVC command: 'dvc run -n FindMaximum ...'\n"
+      "2022-03-16 13:29:28,486 (WARNING): Running DVC command: 'dvc run -n FindMaximum ...'\n"
      ]
     }
    ],
@@ -286,8 +286,82 @@
    }
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "In addition to the introduced classmethod `Node.load(name=\"nodename\")` it is also possible to use `Node[\"nodename\"]`. Note that this only works for `Node[\"nodename\"]` and not for `Node()[\"nodename\"]`. Using this we can also write the following:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
    "cell_type": "code",
    "execution_count": 13,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "17\n",
+      "Test01\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(HelloWorld[\"Test01\"].outputs)\n",
+    "print(HelloWorld[\"Test01\"].node_name)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "this is equivalent to the classmethod `load()`. It is also possible to pass a dictionary as kwargs which will be passed to `load(**kwargs)`."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "42\n",
+      "Test02\n",
+      "42\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(HelloWorld.load(\"Test02\").outputs)\n",
+    "print(HelloWorld.load(\"Test02\").node_name)\n",
+    "print(HelloWorld[{\"name\": \"Test02\"}].outputs)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
    "id": "7b59179c-0b15-45a6-97b1-b2d6cc1ebce3",
    "metadata": {
     "nbsphinx": "hidden",

--- a/examples/docs/09_lazy.ipynb
+++ b/examples/docs/09_lazy.ipynb
@@ -127,7 +127,7 @@
    "outputs": [],
    "source": [
     "class PrintOption(zn.outs):\n",
-    "    dvc_option = \"outs\" \n",
+    "    dvc_option = \"outs\"\n",
     "    # zntrack will try dvc --PrintOption outs.json\n",
     "    # we must tell it to use dvc --outs outs.json instead\n",
     "    def get_data_from_files(self, instance):\n",
@@ -737,7 +737,10 @@
    ],
    "source": [
     "# with lazy we get the same number for every run which is not what we expect.\n",
-    "print(f\"{random_number_lazy_1.number} == {random_number_lazy_2.number} == {random_number_lazy_3.number}\")"
+    "print(\n",
+    "    f\"{random_number_lazy_1.number} == {random_number_lazy_2.number} ==\"\n",
+    "    f\" {random_number_lazy_3.number}\"\n",
+    ")"
    ]
   },
   {

--- a/tests/integration_tests/test_node_to_node_dependencies.py
+++ b/tests/integration_tests/test_node_to_node_dependencies.py
@@ -26,6 +26,10 @@ class ZnOuts(Node):
     def run(self):
         self.data = "Lorem Ipsum"
 
+    @property
+    def reverse(self):
+        return self.data[::-1]
+
 
 class DVCZnOuts(Node):
     data_file: Path = dvc.outs()
@@ -248,3 +252,18 @@ def test_getdeps_named_multi(proj_path):
 
     assert DependenciesCollector.load().dependencies[0].read_text() == "Lorem Ipsum"
     assert DependenciesCollector.load().dependencies[1] == "Lorem Ipsum"
+
+
+@pytest.mark.parametrize("load", (True, False))
+def test_getdeps_property(proj_path, load):
+    ZnOuts().write_graph()
+    if load:
+        deps = getdeps(ZnOuts.load(), "reverse")
+    else:
+        deps = getdeps(ZnOuts, "reverse")
+
+    DependenciesCollector(dependencies=deps).write_graph()
+
+    subprocess.check_call(["dvc", "repro"])
+
+    assert DependenciesCollector.load().dependencies == "muspI meroL"

--- a/tests/unit_tests/zn/test_zn_options.py
+++ b/tests/unit_tests/zn/test_zn_options.py
@@ -6,6 +6,7 @@ import pytest
 import znjson
 
 from zntrack import zn
+from zntrack.zn.dependencies import NodeAttribute, getdeps
 from zntrack.zn.split_option import combine_values, split_value
 
 
@@ -112,3 +113,19 @@ def test_split_value_path():
     new_path = combine_values(zntrack_data, params_data)
     # TODO change order to be consistent with split_values
     assert new_path == path
+
+
+class ExampleNode:
+    module = "module"
+    node_name = "node01"
+    affected_files = ["a", "b"]
+
+
+def test_getdeps():
+    assert getdeps(ExampleNode(), "my_attr") == NodeAttribute(
+        module="module",
+        cls="ExampleNode",
+        name="node01",
+        attribute="my_attr",
+        affected_files=["a", "b"],
+    )

--- a/zntrack/__init__.py
+++ b/zntrack/__init__.py
@@ -19,13 +19,19 @@ from zntrack.core.functions.decorator import NodeConfig, nodify
 from zntrack.interface.base import DVCInterface
 from zntrack.project.zntrack_project import ZnTrackProject
 from zntrack.utils.config import config
-from zntrack.utils.serializer import MethodConverter, ZnTrackTypeConverter
+from zntrack.utils.serializer import (
+    MethodConverter,
+    NodeAttributeConverter,
+    ZnTrackTypeConverter,
+)
+from zntrack.zn.dependencies import getdeps
 
 # register converters
 znjson.config.ACTIVE_CONVERTER = [
     ZnTrackTypeConverter,
     znjson.PathlibConverter,
     MethodConverter,
+    NodeAttributeConverter,
 ]
 try:
     znjson.register([znjson.NumpyConverter, znjson.SmallNumpyConverter])
@@ -40,6 +46,7 @@ __all__ = [
     "config",
     nodify.__name__,
     NodeConfig.__name__,
+    "getdeps",
 ]
 
 __version__ = "0.3.5"

--- a/zntrack/core/dvcgraph.py
+++ b/zntrack/core/dvcgraph.py
@@ -8,6 +8,7 @@ import typing
 from zntrack import descriptor, utils
 from zntrack.core.jupyter import jupyter_class_to_file
 from zntrack.core.zntrackoption import ZnTrackOption
+from zntrack.zn.dependencies import NodeAttribute
 
 log = logging.getLogger(__name__)
 
@@ -36,6 +37,11 @@ def handle_deps(value) -> list:
                 script += ["--deps", pathlib.Path(file).as_posix()]
         elif isinstance(value, (str, pathlib.Path)):
             script += ["--deps", pathlib.Path(value).as_posix()]
+        elif isinstance(value, NodeAttribute):
+            # TODO this will not define the correct dependencies,
+            #  it will define all dependencies of the Node.
+            for file in value.affected_files:
+                script += ["--deps", pathlib.Path(file).as_posix()]
         elif value is None:
             pass
         else:

--- a/zntrack/core/dvcgraph.py
+++ b/zntrack/core/dvcgraph.py
@@ -32,16 +32,11 @@ def handle_deps(value) -> list:
         for lst_val in value:
             script += handle_deps(lst_val)
     else:
-        if isinstance(value, GraphWriter):
+        if isinstance(value, (GraphWriter, NodeAttribute)):
             for file in value.affected_files:
                 script += ["--deps", pathlib.Path(file).as_posix()]
         elif isinstance(value, (str, pathlib.Path)):
             script += ["--deps", pathlib.Path(value).as_posix()]
-        elif isinstance(value, NodeAttribute):
-            # TODO this will not define the correct dependencies,
-            #  it will define all dependencies of the Node.
-            for file in value.affected_files:
-                script += ["--deps", pathlib.Path(file).as_posix()]
         elif value is None:
             pass
         else:

--- a/zntrack/utils/helpers.py
+++ b/zntrack/utils/helpers.py
@@ -1,8 +1,7 @@
-from zntrack.core.base import Node
-
-
 def isnode(node) -> bool:
     """Check if node contains a Node instance or class"""
+    from zntrack.core.base import Node
+
     if isinstance(node, (list, tuple)):
         return any([isnode(x) for x in node])
     else:

--- a/zntrack/utils/serializer.py
+++ b/zntrack/utils/serializer.py
@@ -100,6 +100,7 @@ class NodeAttributeConverter(znjson.ConverterBase):
 
     instance = NodeAttribute
     representation = "NodeAttribute"
+    level = 10
 
     def _encode(self, obj: NodeAttribute) -> dict:
         """Convert NodeAttribute to serializable dict"""

--- a/zntrack/zn/__init__.py
+++ b/zntrack/zn/__init__.py
@@ -61,7 +61,7 @@ class deps(ZnTrackOption):
     def __get__(self, instance, owner):
         """Use load_node_dependency before returning the value"""
         value = super(deps, self).__get__(instance, owner)
-        value = utils.utils.load_node_dependency(value)
+        value = utils.utils.load_node_dependency(value)  # use value = Cls.load()
         setattr(instance, self.name, value)
         return value
 

--- a/zntrack/zn/dependencies.py
+++ b/zntrack/zn/dependencies.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import dataclasses
 import pathlib
-from typing import List, Protocol, Set
+from typing import TYPE_CHECKING, Set
 
 from zntrack.utils import utils
+
+if TYPE_CHECKING:
+    from zntrack import Node
 
 
 @dataclasses.dataclass
@@ -14,23 +19,7 @@ class NodeAttribute:
     affected_files: Set[pathlib.Path]
 
 
-class TypeNode(Protocol):
-    """Duck type typehints for Node"""
-
-    @property
-    def module(self) -> str:
-        ...
-
-    @property
-    def node_name(self) -> str:
-        ...
-
-    @property
-    def affected_files(self) -> List[pathlib.Path]:
-        ...
-
-
-def getdeps(node: TypeNode, attribute: str) -> NodeAttribute:
+def getdeps(node: Node, attribute: str) -> NodeAttribute:
     """Allow for Node attributes as dependencies
 
     Parameters

--- a/zntrack/zn/dependencies.py
+++ b/zntrack/zn/dependencies.py
@@ -1,0 +1,52 @@
+import dataclasses
+import pathlib
+from typing import List, Protocol, Set
+
+from zntrack.utils import utils
+
+
+@dataclasses.dataclass
+class NodeAttribute:
+    module: str
+    cls: str
+    name: str
+    attribute: str
+    affected_files: Set[pathlib.Path]
+
+
+class TypeNode(Protocol):
+    """Duck type typehints for Node"""
+
+    @property
+    def module(self) -> str:
+        ...
+
+    @property
+    def node_name(self) -> str:
+        ...
+
+    @property
+    def affected_files(self) -> List[pathlib.Path]:
+        ...
+
+
+def getdeps(node: TypeNode, attribute: str) -> NodeAttribute:
+    """Allow for Node attributes as dependencies
+
+    Parameters
+    ----------
+    node
+    attribute
+
+    Returns
+    -------
+
+    """
+    node = utils.load_node_dependency(node)  # run node = Node.load() if required
+    return NodeAttribute(
+        module=node.module,
+        cls=node.__class__.__name__,
+        name=node.node_name,
+        attribute=attribute,
+        affected_files=list(node.affected_files),
+    )

--- a/zntrack/zn/dependencies.py
+++ b/zntrack/zn/dependencies.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import pathlib
-from typing import TYPE_CHECKING, Set
+from typing import TYPE_CHECKING, List
 
 from zntrack.utils import utils
 
@@ -16,7 +16,7 @@ class NodeAttribute:
     cls: str
     name: str
     attribute: str
-    affected_files: Set[pathlib.Path]
+    affected_files: List[pathlib.Path]
 
 
 def getdeps(node: Node, attribute: str) -> NodeAttribute:


### PR DESCRIPTION
This PR allows you to directly depend on other nodes attributes and not only rely on the full Node.

```py
class Node1(Node):
    outs: int = zn.outs()
    
class Node2(Node):
    node_1_outs: int = zn.deps(getdeps(Node1, "outs"))
    # or
    node_1_outs: int = zn.deps(getdeps(Node1.load(name="nodename"), "outs"))
    # or
    node_1_outs: int = zn.deps(getdeps(Node1["nodename"], "outs"))
```

# TODOs
- [x] check type hints for `getdeps`
- [x] write tests for properties
- [x] ~~update `affected_files` to include only the required files.~~ This is not possible, because e.g. property dependencies can not be evaluated (easily)
- [x] update documentation (include new load method via getitem)