### PR TITLE
Pylint perflint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -52,8 +52,8 @@ jobs:
           pip install .
       - name: Install pylint
         run: |
-          pip install pylint
+          pip install pylint perflint
       - name: run pylint
         continue-on-error: true
         run: |
-          pylint zntrack
+          pylint zntrack --load-plugins=perflint

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -6,6 +6,8 @@ name: pytest
 on:
   push:
   pull_request:
+  schedule:
+    - cron: '14 3 * * 1'  # at 03:14 on Monday.
 
 jobs:
   test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ disable = [
     "logging-fstring-interpolation",
     "too-many-arguments",
     "too-many-instance-attributes",
+    "dotted-import-in-loop",
     # seems to fail for some cases
     "no-else-return",
     # allow for open TODOs

--- a/tests/integration_tests/test_single_node.py
+++ b/tests/integration_tests/test_single_node.py
@@ -306,9 +306,5 @@ def test_load_named_nodes(proj_path):
     assert ExampleNode01["Node02"].outputs == 3.1415
 
     # this will run load with name=Node01, lazy=True/False
-    assert ExampleNode01[("Node01", True)].outputs == 42
-    assert ExampleNode01[("Node01", False)].outputs == 42
-
-    # this will run load with name=Node01, lazy=True/False
     assert ExampleNode01[{"name": "Node01", "lazy": True}].outputs == 42
     assert ExampleNode01[{"name": "Node01", "lazy": False}].outputs == 42

--- a/tests/integration_tests/test_zn_deps.py
+++ b/tests/integration_tests/test_zn_deps.py
@@ -111,3 +111,26 @@ def test_assert_read_file(proj_path, zntrack_dict):
     pathlib.Path("zntrack.json").write_text(json.dumps(zntrack_dict))
 
     assert isinstance(LastNode.load().first_node, FirstNode)
+
+
+class FirstNodeParams(Node):
+    number: int = zn.params()
+
+
+class SecondNodeParams(Node):
+    first_node_params: FirstNodeParams = zn.deps(FirstNodeParams)
+
+    negative_number: int = zn.params()
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.negative_number = -1 * self.first_node_params.number
+
+
+@pytest.mark.parametrize("number", (5, -5))
+def test_ParamsFromNodeNoLoad(proj_path, number):
+    FirstNodeParams(number=number).write_graph()
+    SecondNodeParams().write_graph()
+
+    assert FirstNodeParams.load().number == number
+    assert SecondNodeParams.load().negative_number == -1 * number

--- a/tests/integration_tests/test_zn_methods.py
+++ b/tests/integration_tests/test_zn_methods.py
@@ -48,6 +48,13 @@ class SingleNode(Node):
         self.result = self.data_class.param1 + self.data_class.param2
 
 
+class HelloWorld(Node):
+    param = zn.params(42)
+
+    def run(self):
+        pass
+
+
 def test_run_twice_diff_params(proj_path):
     SingleNode(data_class=ExampleMethod(1, 1)).write_graph(no_exec=False)
     assert SingleNode.load().result == 2
@@ -224,3 +231,19 @@ def test_assert_read_files_old1(proj_path):
     node = SingleNodeNoParams.load()
     assert node.data_class.param1 == 1
     assert node.data_class.param2 == 2
+
+
+def test_err_node_as_method(proj_path):
+    HelloWorld().write_graph()
+
+    with pytest.raises(ValueError):
+        SingleNode(data_class=HelloWorld.load())
+
+    with pytest.raises(ValueError):
+        SingleNode(data_class=[HelloWorld.load(), HelloWorld.load()])
+
+    with pytest.raises(ValueError):
+        SingleNode(data_class=HelloWorld)
+
+    with pytest.raises(ValueError):
+        SingleNode(data_class=[HelloWorld, HelloWorld])

--- a/tests/unit_tests/core/test_core_base.py
+++ b/tests/unit_tests/core/test_core_base.py
@@ -6,7 +6,12 @@ import pytest
 import yaml
 
 from zntrack import dvc, zn
-from zntrack.core.base import Node, get_auto_init_signature, update_dependency_options
+from zntrack.core.base import (
+    LoadViaGetItem,
+    Node,
+    get_auto_init_signature,
+    update_dependency_options,
+)
 
 
 class ExampleDVCOutsNode(Node):
@@ -222,3 +227,23 @@ def test_get_auto_init_signature():
     assert signature_params[2].annotation is None
 
     assert signature_params[-1].name == "out3"
+
+
+class NodeMock(metaclass=LoadViaGetItem):
+    def load(self):
+        pass
+
+
+@pytest.mark.parametrize(
+    ("key", "called"),
+    [
+        ("node", {"name": "node"}),
+        ({"name": "node"}, {"name": "node"}),
+        ({"name": "node", "lazy": True}, {"name": "node", "lazy": True}),
+    ],
+)
+def test_LoadViaGetItem(key, called):
+    with patch.object(NodeMock, "load") as mock:
+        NodeMock[key]
+
+    mock.assert_called_with(**called)

--- a/tests/unit_tests/utlis/test_helpers.py
+++ b/tests/unit_tests/utlis/test_helpers.py
@@ -1,0 +1,24 @@
+import pytest
+
+from zntrack import Node
+from zntrack.utils import helpers
+
+
+class MyNode(Node):
+    def run(self):
+        pass
+
+
+@pytest.mark.parametrize(
+    ("node", "true_val"),
+    [
+        (MyNode(), True),
+        (MyNode, True),
+        ([MyNode, MyNode], True),
+        ([MyNode(), MyNode()], True),
+        ("Node", False),
+        (["Node", MyNode()], True),
+    ],
+)
+def test_isnode(node, true_val):
+    assert helpers.isnode(node) == true_val

--- a/zntrack/__init__.py
+++ b/zntrack/__init__.py
@@ -22,12 +22,7 @@ from zntrack.utils.config import config
 from zntrack.utils.serializer import MethodConverter, ZnTrackTypeConverter
 
 # register converters
-znjson.register(
-    [
-        ZnTrackTypeConverter,
-        MethodConverter,
-    ]
-)
+znjson.register([ZnTrackTypeConverter, MethodConverter])
 
 __all__ = [
     Node.__name__,

--- a/zntrack/__init__.py
+++ b/zntrack/__init__.py
@@ -25,7 +25,6 @@ from zntrack.utils.serializer import MethodConverter, ZnTrackTypeConverter
 znjson.register(
     [
         ZnTrackTypeConverter,
-        znjson.PathlibConverter,
         MethodConverter,
     ]
 )

--- a/zntrack/__init__.py
+++ b/zntrack/__init__.py
@@ -22,17 +22,14 @@ from zntrack.utils.config import config
 from zntrack.utils.serializer import MethodConverter, ZnTrackTypeConverter
 
 # register converters
-znjson.config.ACTIVE_CONVERTER = [
-    ZnTrackTypeConverter,
-    znjson.PathlibConverter,
-    MethodConverter,
-]
-try:
-    znjson.register([znjson.NumpyConverter, znjson.SmallNumpyConverter])
-except AttributeError:
-    pass
+znjson.register(
+    [
+        ZnTrackTypeConverter,
+        znjson.PathlibConverter,
+        MethodConverter,
+    ]
+)
 
-#
 __all__ = [
     Node.__name__,
     ZnTrackProject.__name__,

--- a/zntrack/core/base.py
+++ b/zntrack/core/base.py
@@ -66,15 +66,12 @@ class LoadViaGetItem(type):
 
         Attributes
         ----------
-        item: str|tuple|dict
+        item: str|dict
             Can be a string, for load(name=item)
-            Can be a tuple for load(*item) | e.g. ("nodename", True)
             Can be a dict for load(**item) | e.g. {name:"nodename", lazy:True}
 
         """
-        if isinstance(item, tuple):
-            return cls.load(*item)
-        elif isinstance(item, dict):
+        if isinstance(item, dict):
             return cls.load(**item)
         return cls.load(name=item)
 

--- a/zntrack/core/base.py
+++ b/zntrack/core/base.py
@@ -52,7 +52,8 @@ def update_dependency_options(value):
     the default_value Nodes, so we must to this manually here and call update_options.
     """
     if isinstance(value, (list, tuple)):
-        [update_dependency_options(x) for x in value]
+        for item in value:
+            update_dependency_options(item)
     if isinstance(value, Node):
         value.update_options()
 
@@ -60,7 +61,7 @@ def update_dependency_options(value):
 class LoadViaGetItem(type):
     """Metaclass for adding getitem support to load"""
 
-    def __getitem__(self: Node, item) -> Node:
+    def __getitem__(cls: Node, item) -> Node:
         """Allow Node[<nodename>] to access an instance of the Node
 
         Attributes
@@ -72,10 +73,10 @@ class LoadViaGetItem(type):
 
         """
         if isinstance(item, tuple):
-            return self.load(*item)
+            return cls.load(*item)
         elif isinstance(item, dict):
-            return self.load(**item)
-        return self.load(name=item)
+            return cls.load(**item)
+        return cls.load(name=item)
 
 
 class Node(GraphWriter, metaclass=LoadViaGetItem):

--- a/zntrack/core/jupyter.py
+++ b/zntrack/core/jupyter.py
@@ -1,12 +1,12 @@
 import logging
-
-log = logging.getLogger(__name__)
 import pathlib
 import re
 import subprocess
 from functools import lru_cache
 
 from zntrack.utils.config import config
+
+log = logging.getLogger(__name__)
 
 
 @lru_cache(None)
@@ -30,6 +30,7 @@ def jupyter_class_to_file(nb_name, module_name):
     subprocess.run(
         ["jupyter", "nbconvert", "--to", "script", nb_name],
         capture_output=config.log_level > logging.INFO,
+        check=True,
     )
 
     reading_class = False

--- a/zntrack/core/zntrackoption.py
+++ b/zntrack/core/zntrackoption.py
@@ -82,7 +82,8 @@ class ZnTrackOption(descriptor.Descriptor):
         super().__init__(default_value=default_value, **kwargs)
 
     @property
-    def dvc_args(self):
+    def dvc_args(self) -> str:
+        """replace python variables '_' with '-' for dvc"""
         return self.dvc_option.replace("_", "-")
 
     def __repr__(self):

--- a/zntrack/dvc/__init__.py
+++ b/zntrack/dvc/__init__.py
@@ -56,7 +56,7 @@ class deps(ZnTrackOption):
 
     def __get__(self, instance, owner):
         """Use load_node_dependency before returning the value"""
-        value = super(deps, self).__get__(instance, owner)
+        value = super().__get__(instance, owner)
         value = utils.utils.load_node_dependency(value, log_warning=True)
         setattr(instance, self.name, value)
         return value

--- a/zntrack/metadata/base.py
+++ b/zntrack/metadata/base.py
@@ -11,6 +11,7 @@ Description:
 
 import re
 from abc import ABC, abstractmethod
+from functools import partial
 from typing import Callable
 
 from zntrack import utils
@@ -59,8 +60,6 @@ class MetaData(ABC):
         See the following answer for a full explanation why this is required
         https://stackoverflow.com/questions/30104047/how-can-i-decorate-an-instance-method-with-a-decorator-class
         """
-
-        from functools import partial
 
         return partial(self.__call__, instance)
 

--- a/zntrack/utils/exceptions.py
+++ b/zntrack/utils/exceptions.py
@@ -16,5 +16,3 @@ class DescriptorMissing(Exception):
 
 class DVCProcessError(Exception):
     """DVC specific message for CalledProcessError"""
-
-    pass

--- a/zntrack/utils/helpers.py
+++ b/zntrack/utils/helpers.py
@@ -1,0 +1,14 @@
+from zntrack.core.base import Node
+
+
+def isnode(node) -> bool:
+    """Check if node contains a Node instance or class"""
+    if isinstance(node, (list, tuple)):
+        return any([isnode(x) for x in node])
+    else:
+        try:
+            if isinstance(node, Node) or issubclass(node, Node):
+                return True
+        except TypeError:
+            pass
+    return False

--- a/zntrack/utils/serializer.py
+++ b/zntrack/utils/serializer.py
@@ -72,6 +72,7 @@ class ZnTrackTypeConverter(znjson.ConverterBase):
 
     instance = Node
     representation = "ZnTrackType"
+    level = 10
 
     def _encode(self, obj: Node) -> dict:
         """Convert Node to serializable dict"""
@@ -98,6 +99,7 @@ class MethodConverter(znjson.ConverterBase):
     """ZnJSON Converter for zn.method attributes"""
 
     representation = "zn.method"
+    level = 10
 
     def _encode(self, obj):
         """Serialize the object"""

--- a/zntrack/utils/utils.py
+++ b/zntrack/utils/utils.py
@@ -148,14 +148,12 @@ def check_type(
         for value in obj:
             if check_type(value, types, allow_iterable, allow_none, allow_dict):
                 continue
-            else:
-                return False
+            return False
     elif isinstance(obj, dict) and allow_dict:
         for value in obj.values():
             if check_type(value, types, allow_iterable, allow_none, allow_dict):
                 continue
-            else:
-                return False
+            return False
     else:
         if allow_none and obj is None:
             return True

--- a/zntrack/zn/__init__.py
+++ b/zntrack/zn/__init__.py
@@ -60,7 +60,7 @@ class deps(ZnTrackOption):
 
     def __get__(self, instance, owner):
         """Use load_node_dependency before returning the value"""
-        value = super(deps, self).__get__(instance, owner)
+        value = super().__get__(instance, owner)
         value = utils.utils.load_node_dependency(value)
         setattr(instance, self.name, value)
         return value

--- a/zntrack/zn/method.py
+++ b/zntrack/zn/method.py
@@ -1,6 +1,6 @@
 import logging
 
-from zntrack import utils
+from zntrack import Node, utils
 from zntrack.zn.split_option import SplitZnTrackOption
 
 log = logging.getLogger(__name__)
@@ -31,6 +31,17 @@ class Method(SplitZnTrackOption):
     def get_filename(self, instance):
         """Does not have a single file but params.yaml and zntrack.json"""
         return utils.Files.params, utils.Files.zntrack
+
+    def __set__(self, instance, value):
+        """Include type check for better error reporting"""
+        # TODO raise error on default values,
+        #  make compatible types an attribute of descriptor
+        if isinstance(instance, Node) or issubclass(instance, None):
+            raise ValueError(
+                "zn.Method() does not support type <Node>."
+                " Consider using zn.deps() instead"
+            )
+        super().__set__(instance, value)
 
     def __get__(self, instance, owner):
         """Add some custom attributes to the instance to identify it in znjson"""

--- a/zntrack/zn/method.py
+++ b/zntrack/zn/method.py
@@ -1,6 +1,7 @@
 import logging
 
-from zntrack import Node, utils
+from zntrack import utils
+from zntrack.utils import helpers
 from zntrack.zn.split_option import SplitZnTrackOption
 
 log = logging.getLogger(__name__)
@@ -36,7 +37,7 @@ class Method(SplitZnTrackOption):
         """Include type check for better error reporting"""
         # TODO raise error on default values,
         #  make compatible types an attribute of descriptor
-        if isinstance(instance, Node) or issubclass(instance, None):
+        if helpers.isnode(instance):
             raise ValueError(
                 "zn.Method() does not support type <Node>."
                 " Consider using zn.deps() instead"

--- a/zntrack/zn/method.py
+++ b/zntrack/zn/method.py
@@ -37,9 +37,9 @@ class Method(SplitZnTrackOption):
         """Include type check for better error reporting"""
         # TODO raise error on default values,
         #  make compatible types an attribute of descriptor
-        if helpers.isnode(instance):
+        if helpers.isnode(value):
             raise ValueError(
-                "zn.Method() does not support type <Node>."
+                f"zn.Method() does not support type <Node> ({value})."
                 " Consider using zn.deps() instead"
             )
         super().__set__(instance, value)

--- a/zntrack/zn/split_option.py
+++ b/zntrack/zn/split_option.py
@@ -39,7 +39,7 @@ def split_value(input_val) -> (typing.Union[dict, list], typing.Union[dict, list
     """
     if isinstance(input_val, (list, tuple)):
         data = [split_value(x) for x in input_val]
-        params_data, zntrack_data = zip(*data)
+        params_data, _ = zip(*data)
     else:
         if input_val["_type"] in ["zn.method"]:
             params_data = input_val["value"].pop("kwargs")


### PR DESCRIPTION
- Add `perflint` to the CI
- remove `Node[(name, lazy)]` tuple access and restrict to name / dict
- raise error when passing a Node to `zn.Method`