### PR TITLE
Add matmul shorthand

### DIFF
--- a/examples/docs/03_dependencies.ipynb
+++ b/examples/docs/03_dependencies.ipynb
@@ -459,7 +459,7 @@
    "outputs": [],
    "source": [
     "class ComputePowerFromNumber(Node):\n",
-    "    number: float = zn.deps()  # this will be float instead of RandomNumber\n",
+    "    number: float = zn.deps()  # this will be a float instead of RandomNumber\n",
     "\n",
     "    power: int = zn.params()\n",
     "    result: float = zn.outs()\n",
@@ -502,7 +502,7 @@
    "cell_type": "markdown",
    "source": [
     "`getdeps(RandomNumber, \"number\")` can also be replaced by `getdeps(RandomNumber[\"nodename\"], \"number\")` or `getdeps(RandomNumber.load(name=\"nodename\"), \"number\")`.\n",
-    "The first argument represents the Node and the second argument is the attribute, similar to `getattr()`."
+    "The first argument represents the Node and the second argument is the attribute, similar to `getattr()`. ZnTrack also provides a shorthand for this via `RandomNumber @ \"number\"` or `RandomNumber[\"nodename\"] @ \"number\"`."
    ],
    "metadata": {
     "collapsed": false,

--- a/tests/unit_tests/core/test_core_base.py
+++ b/tests/unit_tests/core/test_core_base.py
@@ -258,3 +258,12 @@ def test_matmul_not_supported():
 
     with pytest.raises(ValueError):
         RunTestNode() @ 25
+
+    with patch("zntrack.core.base.getdeps") as mock:
+        # must patch the correct namespace
+        # https://stackoverflow.com/a/16134754/10504481
+        NodeMock @ "string"
+        RunTestNode @ "outs"
+        RunTestNode() @ "outs"
+
+    assert mock.call_count == 3

--- a/tests/unit_tests/core/test_core_base.py
+++ b/tests/unit_tests/core/test_core_base.py
@@ -249,3 +249,12 @@ def test_LoadViaGetItem(key, called):
         NodeMock[key]
 
     mock.assert_called_with(**called)
+
+
+def test_matmul_not_supported():
+    with pytest.raises(ValueError):
+        # must be str
+        RunTestNode @ 25
+
+    with pytest.raises(ValueError):
+        RunTestNode() @ 25

--- a/zntrack/core/base.py
+++ b/zntrack/core/base.py
@@ -6,6 +6,7 @@ import logging
 from zntrack import utils
 from zntrack.core.dvcgraph import GraphWriter
 from zntrack.core.zntrackoption import ZnTrackOption
+from zntrack.zn.dependencies import NodeAttribute, getdeps
 
 log = logging.getLogger(__name__)
 
@@ -65,6 +66,24 @@ class LoadViaGetItem(type):
             return cls.load(**item)
         return cls.load(name=item)
 
+    def __matmul__(self, other: str) -> NodeAttribute:
+        """Shorthand for: getdeps(Node, other)
+
+        Parameters
+        ----------
+        other: str
+            Name of the class attribute
+
+        Returns
+        -------
+        NodeAttribute
+        """
+        if not isinstance(other, str):
+            raise ValueError(
+                f"Can not compute 'Node @ {type(other)}'. Expected 'Node @ str'."
+            )
+        return getdeps(self, other)
+
 
 class Node(GraphWriter, metaclass=LoadViaGetItem):
     """Main parent class for all ZnTrack Node
@@ -101,6 +120,24 @@ class Node(GraphWriter, metaclass=LoadViaGetItem):
     def __repr__(self):
         origin = super().__repr__()
         return f"{origin}(name={self.node_name})"
+
+    def __matmul__(self, other: str) -> NodeAttribute:
+        """Shorthand for: getdeps(Node, other)
+
+        Parameters
+        ----------
+        other: str
+            Name of the class attribute
+
+        Returns
+        -------
+        NodeAttribute
+        """
+        if not isinstance(other, str):
+            raise ValueError(
+                f"Can not compute 'Node @ {type(other)}'. Expected 'Node @ str'."
+            )
+        return getdeps(self, other)
 
     def __init_subclass__(cls, **kwargs):
         """Add a dataclass-like init if None is provided"""

--- a/zntrack/zn/dependencies.py
+++ b/zntrack/zn/dependencies.py
@@ -31,6 +31,8 @@ def getdeps(node: Union[Node, type(Node)], attribute: str) -> NodeAttribute:
     -------
 
     """
+    # TODO add check if the attribute exists in the given Node
+    # _ = getattr(node, attribute)
     node = utils.load_node_dependency(node)  # run node = Node.load() if required
     return NodeAttribute(
         module=node.module,


### PR DESCRIPTION
In addition to `getdeps(Node, "attribute")` you can now use `Node @ "attribute"` without the need of importing `from zntrack import getdeps`.

This allows users who prefer the `@` shorthand to use that. For the documentation the usage of `getdeps` should be prefered, because it better shows what is happening.