### PR TITLE
Generate `df.index.name` if not provided

### DIFF
--- a/tests/integration_tests/test_zn_plots.py
+++ b/tests/integration_tests/test_zn_plots.py
@@ -55,8 +55,9 @@ def test_load_plots(proj_path):
 
 
 def test_write_plots_value_error(proj_path):
-    with pytest.raises(ValueError):
-        WritePlotsNoIndex().run_and_save()
+    WritePlotsNoIndex().run_and_save()
+    wpni = WritePlotsNoIndex.load()
+    assert wpni.plots.index.name == "index"
 
 
 def test_write_plots_type_error(proj_path):

--- a/tests/integration_tests/test_zn_plots.py
+++ b/tests/integration_tests/test_zn_plots.py
@@ -23,7 +23,7 @@ class WritePlots(Node):
 
     def run(self):
         self.plots = pd.DataFrame({"value": [x for x in range(100)]})
-        self.plots.index.name = "index"
+        self.plots.index.name = "my_index"
 
 
 class WritePlotsNoIndex(Node):
@@ -43,6 +43,9 @@ class WritePlotsWrongData(Node):
 def test_write_plots(proj_path):
     WritePlots().write_graph(no_exec=False)
     subprocess.check_call(["dvc", "plots", "show"])
+
+    wp = WritePlots.load()
+    assert wp.plots.index.name == "my_index"
 
 
 def test_load_plots(proj_path):

--- a/zntrack/zn/plots.py
+++ b/zntrack/zn/plots.py
@@ -30,10 +30,7 @@ class plots(ZnTrackOption):
             )
 
         if value.index.name is None:
-            raise ValueError(
-                "pd.DataFrame must have an index name! You can set the name via"
-                " DataFrame.index.name = <index name>."
-            )
+            value.index.name = "index"
 
         file = self.get_filename(instance)
         file.parent.mkdir(exist_ok=True, parents=True)


### PR DESCRIPTION
set `df.index.name="index"` if no index is provided to work with DVC.

fix #261 