### PR TITLE
bugfix: change plots filename

### DIFF
--- a/zntrack/zn/plots.py
+++ b/zntrack/zn/plots.py
@@ -15,7 +15,7 @@ class plots(ZnTrackOption):
 
     def get_filename(self, instance) -> pathlib.Path:
         """Overwrite filename to csv"""
-        return pathlib.Path("nodes", instance.node_name, f"{self.dvc_option}.csv")
+        return pathlib.Path("nodes", instance.node_name, f"{self.name}.csv")
 
     def save(self, instance):
         """Save value with pd.DataFrame.to_csv"""


### PR DESCRIPTION
When multiple zn.plots where defined they would overwrite each other. Using different filenames prohibits this.