### PR TITLE
add `zntrack.collect` as Node attribute

### DIFF
--- a/tests/integration_tests/test_single_node.py
+++ b/tests/integration_tests/test_single_node.py
@@ -325,3 +325,24 @@ def test_load_named_nodes(proj_path):
     # this will run load with name=Node01, lazy=True/False
     assert ExampleNode01[{"name": "Node01", "lazy": True}].outputs == 42
     assert ExampleNode01[{"name": "Node01", "lazy": False}].outputs == 42
+
+
+def test_collect(proj_path):
+    ExampleNode01(inputs="Hello World").write_graph(run=True)
+    assert ExampleNode01.load().zntrack.collect(zn.params) == {"inputs": "Hello World"}
+    assert ExampleNode01.load().zntrack.collect(zn.outs) == {"outputs": "Hello World"}
+
+    SingleNodeNoInit(param1=25, param2=42).write_graph(run=True)
+    assert SingleNodeNoInit.load().zntrack.collect(zn.params) == {
+        "param1": 25,
+        "param2": 42,
+    }
+    assert SingleNodeNoInit.load().zntrack.collect(zn.outs) == {"result": 67}
+
+    ExampleNode01(inputs={"Hello": "World"}, name="TestNode").write_graph(run=True)
+    assert ExampleNode01["TestNode"].zntrack.collect(zn.params) == {
+        "inputs": {"Hello": "World"}
+    }
+
+    with pytest.raises(ValueError):
+        ExampleNode01["TestNode"].zntrack.collect((zn.params, zn.outs))

--- a/tests/unit_tests/core/test_dvcgraph.py
+++ b/tests/unit_tests/core/test_dvcgraph.py
@@ -6,6 +6,7 @@ from zntrack import dvc, utils, zn
 from zntrack.core.dvcgraph import (
     DVCRunOptions,
     GraphWriter,
+    ZnTrackInfo,
     filter_ZnTrackOption,
     handle_deps,
     handle_dvc,
@@ -192,3 +193,20 @@ def test_prepare_dvc_script():
         f'{utils.get_python_interpreter()} -c "from src.file import MyNode;'
         ' MyNode.load().run_and_save()" ',
     ]
+
+
+def test_ZnTrackInfo():
+    node = GraphWriter()
+    assert isinstance(node.zntrack, ZnTrackInfo)
+    assert node.zntrack._parent == node
+
+
+def test_ZnTrackInfo_collect():
+    node = GraphWriter()
+
+    with pytest.raises(ValueError):
+        node.zntrack.collect([zn.params, zn.outs])
+
+    example = ExampleClassWithParams()
+
+    assert example.zntrack.collect(zn.params) == {"param1": 1, "param2": 2}

--- a/tests/unit_tests/descriptor/test_descriptor.py
+++ b/tests/unit_tests/descriptor/test_descriptor.py
@@ -73,3 +73,53 @@ def test_get_descriptors_exceptions():
 
     with pytest.raises(ValueError):
         get_descriptors(Descriptor, self=ExampleCls(), cls=ExampleCls)
+
+
+class CustomDescriptor1(Descriptor):
+    pass
+
+
+class CustomDescriptor2(Descriptor):
+    pass
+
+
+class MultipleDescriptors:
+    desc1_1 = CustomDescriptor1()
+    desc1_2 = CustomDescriptor1()
+
+    desc2_1 = CustomDescriptor2()
+    desc2_2 = CustomDescriptor2()
+
+
+def test_get_custom_descriptors():
+    cls = MultipleDescriptors
+    assert get_descriptors(Descriptor, cls=cls) == [
+        cls.desc1_1,
+        cls.desc1_2,
+        cls.desc2_1,
+        cls.desc2_2,
+    ]
+    assert get_descriptors(CustomDescriptor1, cls=cls) == [cls.desc1_1, cls.desc1_2]
+    assert get_descriptors(CustomDescriptor2, cls=cls) == [cls.desc2_1, cls.desc2_2]
+
+    self = MultipleDescriptors()
+    assert get_descriptors(Descriptor, self=self) == [
+        cls.desc1_1,
+        cls.desc1_2,
+        cls.desc2_1,
+        cls.desc2_2,
+    ]
+    assert get_descriptors(CustomDescriptor1, self=self) == [cls.desc1_1, cls.desc1_2]
+    assert get_descriptors(CustomDescriptor2, self=self) == [cls.desc2_1, cls.desc2_2]
+
+
+def test_get_desc_values():
+    self = MultipleDescriptors()
+
+    self.desc1_1 = "Hello"
+    self.desc1_2 = "World"
+
+    desc1_1, desc1_2 = get_descriptors(CustomDescriptor1, self=self)
+
+    assert desc1_1.__get__(self) == "Hello"
+    assert desc1_2.__get__(self) == "World"

--- a/zntrack/core/base.py
+++ b/zntrack/core/base.py
@@ -51,10 +51,13 @@ def update_dependency_options(value):
         value.update_options()
 
 
+BaseNodeType = typing.TypeVar("BaseNodeType", bound="Node")
+
+
 class LoadViaGetItem(type):
     """Metaclass for adding getitem support to load"""
 
-    def __getitem__(cls: Node, item) -> Node:
+    def __getitem__(cls: Node, item) -> BaseNodeType:
         """Allow Node[<nodename>] to access an instance of the Node
 
         Attributes

--- a/zntrack/core/dvcgraph.py
+++ b/zntrack/core/dvcgraph.py
@@ -205,6 +205,35 @@ def prepare_dvc_script(
     return script
 
 
+class ZnTrackInfo:
+    """Helping class for access to ZnTrack information"""
+
+    def __init__(self, parent):
+        self.parent = parent
+
+    def collect(self, zntrackoption: descriptor.BaseDescriptorType) -> dict:
+        """Collect the values of all ZnTrackOptions of the passed type
+
+        Parameters
+        ----------
+        zntrackoption:
+            Any cls of a ZnTrackOption such as zn.params
+
+        Returns
+        -------
+        dict:
+            A dictionary of {option_name: option_value} for all found options of
+            the given type zntrackoption.
+        """
+        if isinstance(zntrackoption, (list, tuple)):
+            raise ValueError(
+                "collect only supports single ZnTrackOptions. Found"
+                f" {zntrackoption} instead."
+            )
+        options = descriptor.get_descriptors(zntrackoption, self=self.parent)
+        return {x.name: x.__get__(self.parent) for x in options}
+
+
 class GraphWriter:
     """Write the DVC Graph
 
@@ -421,6 +450,10 @@ class GraphWriter:
         utils.run_dvc_cmd(script)
 
         run_post_dvc_cmd(descriptor_list=self._descriptor_list, instance=self)
+
+    @property
+    def zntrack(self) -> ZnTrackInfo:
+        return ZnTrackInfo(parent=self)
 
 
 def run_post_dvc_cmd(descriptor_list, instance):

--- a/zntrack/core/dvcgraph.py
+++ b/zntrack/core/dvcgraph.py
@@ -209,7 +209,7 @@ class ZnTrackInfo:
     """Helping class for access to ZnTrack information"""
 
     def __init__(self, parent):
-        self.parent = parent
+        self._parent = parent
 
     def collect(self, zntrackoption: descriptor.BaseDescriptorType) -> dict:
         """Collect the values of all ZnTrackOptions of the passed type
@@ -230,8 +230,8 @@ class ZnTrackInfo:
                 "collect only supports single ZnTrackOptions. Found"
                 f" {zntrackoption} instead."
             )
-        options = descriptor.get_descriptors(zntrackoption, self=self.parent)
-        return {x.name: x.__get__(self.parent) for x in options}
+        options = descriptor.get_descriptors(zntrackoption, self=self._parent)
+        return {x.name: x.__get__(self._parent) for x in options}
 
 
 class GraphWriter:

--- a/zntrack/core/zntrackoption.py
+++ b/zntrack/core/zntrackoption.py
@@ -94,7 +94,7 @@ class ZnTrackOption(descriptor.Descriptor):
     def __str__(self):
         return f"{self.dvc_option} / {self.name}"
 
-    def __get__(self, instance, owner):
+    def __get__(self, instance, owner=None):
         self._instance = instance
 
         if instance is None:

--- a/zntrack/descriptor/__init__.py
+++ b/zntrack/descriptor/__init__.py
@@ -1,3 +1,6 @@
+import typing
+
+
 class Descriptor:
     """Simple Python Descriptor that allows adding
 
@@ -60,7 +63,7 @@ class Descriptor:
         self._owner = owner
         self._name = name
 
-    def __get__(self, instance, owner):
+    def __get__(self, instance, owner=None):
         """Get from instance.__dict__"""
         self._instance = instance
         if instance is None:
@@ -73,7 +76,12 @@ class Descriptor:
         instance.__dict__[self.name] = value
 
 
-def get_descriptors(descriptor=None, *, self=None, cls=None) -> list:
+BaseDescriptorType = typing.TypeVar("BaseDescriptorType", bound=Descriptor)
+
+
+def get_descriptors(
+    descriptor=None, *, self=None, cls=None
+) -> typing.List[BaseDescriptorType]:
     """Get a list of all descriptors inheriting from "descriptor"
 
     Parameters
@@ -102,7 +110,7 @@ def get_descriptors(descriptor=None, *, self=None, cls=None) -> list:
                 lst.append(value)
         except AttributeError as err:
             raise AttributeError(
-                "Trying to call ZnTrackOption.__get__(instance=None) to retreive the"
+                "Trying to call ZnTrackOption.__get__(instance=None) to retrieve the"
                 " <ZnTrackOption>. Make sure you implemented that case in the __get__"
                 " method."
             ) from err

--- a/zntrack/dvc/__init__.py
+++ b/zntrack/dvc/__init__.py
@@ -43,7 +43,7 @@ class deps(ZnTrackOption):
     zn_type = utils.ZnTypes.DEPS
     file = utils.Files.zntrack
 
-    def __get__(self, instance, owner):
+    def __get__(self, instance, owner=None):
         """Use load_node_dependency before returning the value"""
         if instance is None:
             return self

--- a/zntrack/zn/__init__.py
+++ b/zntrack/zn/__init__.py
@@ -50,7 +50,7 @@ class deps(ZnTrackOption):
     zn_type = utils.ZnTypes.DEPS
     file = utils.Files.zntrack
 
-    def __get__(self, instance, owner):
+    def __get__(self, instance, owner=None):
         """Use load_node_dependency before returning the value"""
         if instance is None:
             return self

--- a/zntrack/zn/method.py
+++ b/zntrack/zn/method.py
@@ -44,7 +44,7 @@ class Method(SplitZnTrackOption):
             )
         super().__set__(instance, value)
 
-    def __get__(self, instance, owner):
+    def __get__(self, instance, owner=None):
         """Add some custom attributes to the instance to identify it in znjson"""
         if instance is None:
             # this must be here, even though it is in the super call, what follows


### PR DESCRIPTION
- Add `Node.zntrack` property which can not be overwritten.
- add `Node.zntrack.collect(<ZnTrackOption>)`

# Example

```py
class ExampleNode01(Node):
    inputs = zn.params()
    outputs = zn.outs()


ExampleNode01(inputs="Hello World").write_graph(run=True)
ExampleNode01.load().zntrack.collect(zn.params) == {"inputs": "Hello World"}
```
for more examples checkout the tests.
