### PR TITLE
Collect metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [tool.poetry]
 name = "ZnTrack"
-version = "0.4.2"
+version = "0.4.3"
 description = "Create, Run and Benchmark DVC Pipelines in Python"
 authors = ["zincwarecode <zincwarecode@gmail.com>"]
 license = "Apache-2.0"
 keywords=["data-science", "data-version-control", "machine-learning", "reproducibility", "collaboration"]
+readme = "README.md"
 
 
 [tool.poetry.dependencies]

--- a/tests/integration_tests/test_metadata.py
+++ b/tests/integration_tests/test_metadata.py
@@ -1,0 +1,19 @@
+import zntrack
+
+
+class NodeInfoNode(zntrack.Node):
+    """This is a simple Test Node"""
+
+    node_info = zntrack.NodeInfo(author="John Doe")
+
+    def run(self):
+        pass
+
+
+def test_NodeInfoNode():
+    assert NodeInfoNode.node_info.author == "John Doe"
+
+    node = NodeInfoNode()
+    node_info = node.zntrack.collect(zntrack.NodeInfo)
+    assert node_info["node_info"].author == "John Doe"
+    assert node_info["node_info"].long_description == "This is a simple Test Node"

--- a/tests/unit_tests/core/test_dvcgraph.py
+++ b/tests/unit_tests/core/test_dvcgraph.py
@@ -7,7 +7,6 @@ from zntrack.core.dvcgraph import (
     DVCRunOptions,
     GraphWriter,
     ZnTrackInfo,
-    filter_ZnTrackOption,
     handle_deps,
     handle_dvc,
     prepare_dvc_script,
@@ -117,14 +116,14 @@ def test__descriptor_list():
 def test_descriptor_list_filter():
     example = ExampleClassWithParams()
 
-    assert filter_ZnTrackOption(
+    assert utils.helpers.filter_ZnTrackOption(
         data=example._descriptor_list, cls=example, zn_type=utils.ZnTypes.PARAMS
     ) == {
         "param1": 1,
         "param2": 2,
     }
 
-    assert filter_ZnTrackOption(
+    assert utils.helpers.filter_ZnTrackOption(
         data=example._descriptor_list,
         cls=example,
         zn_type=utils.ZnTypes.PARAMS,

--- a/zntrack/__init__.py
+++ b/zntrack/__init__.py
@@ -7,6 +7,7 @@ import znjson
 from zntrack.core.base import Node
 from zntrack.core.functions.decorator import NodeConfig, nodify
 from zntrack.interface.base import DVCInterface
+from zntrack.metadata.collectors import NodeInfo, RunInfo
 from zntrack.project.zntrack_project import ZnTrackProject
 from zntrack.utils.config import config
 from zntrack.utils.serializer import (
@@ -27,6 +28,8 @@ __all__ = [
     nodify.__name__,
     NodeConfig.__name__,
     "getdeps",
+    NodeInfo.__name__,
+    RunInfo.__name__,
 ]
 
 __version__ = importlib.metadata.version("zntrack")

--- a/zntrack/core/base.py
+++ b/zntrack/core/base.py
@@ -8,6 +8,7 @@ from zntrack import utils
 from zntrack.core.dvcgraph import GraphWriter
 from zntrack.core.zntrackoption import ZnTrackOption
 from zntrack.descriptor import get_descriptors
+from zntrack.metadata.collectors import NodeInfo
 from zntrack.zn.dependencies import NodeAttribute, getdeps
 
 log = logging.getLogger(__name__)
@@ -110,6 +111,11 @@ class Node(GraphWriter, metaclass=LoadViaGetItem):
         for data in self._descriptor_list:
             if data.zn_type == utils.ZnTypes.DEPS:
                 update_dependency_options(data.default_value)
+
+        node_info = self.zntrack.collect(NodeInfo)
+        if len(node_info) != 0:
+            node_info = next(iter(node_info.values()))
+            node_info.update_from_docstring(self.__doc__)
 
     @utils.deprecated(
         reason=(
@@ -225,7 +231,7 @@ class Node(GraphWriter, metaclass=LoadViaGetItem):
     def _update_options(self, lazy=None):
         """Update all ZnTrack options inheriting from ZnTrackOption
 
-        This will overwrite the value in __dict__ even it the value was changed
+        This will overwrite the value in __dict__ even if the value was changed
         """
         if lazy is None:
             lazy = utils.config.lazy

--- a/zntrack/core/dvcgraph.py
+++ b/zntrack/core/dvcgraph.py
@@ -113,56 +113,6 @@ def handle_dvc(value, dvc_args) -> list:
     return [f(x) for x in value for f in (option_func, posix_func)]
 
 
-def filter_ZnTrackOption(
-    data,
-    cls,
-    zn_type: typing.Union[utils.ZnTypes, typing.List[utils.ZnTypes]],
-    return_with_type=False,
-    allow_none: bool = False,
-) -> dict:
-    """Filter the descriptor instances by zn_type
-
-    Parameters
-    ----------
-    data: List[ZnTrackOption]
-        The ZnTrack options to query through
-    cls:
-        The instance the ZnTrack options are attached to
-    zn_type: str
-        The zn_type of the descriptors to gather
-    return_with_type: bool, default=False
-        return a dictionary with the Descriptor.dvc_option as keys
-    allow_none: bool, default=False
-        Use getattr(obj, name, None) instead of getattr(obj, name) to yield
-        None when an AttributeError occurs.
-
-    Returns
-    -------
-    dict:
-        either {attr_name: attr_value}
-        or
-        {descriptor.dvc_option: {attr_name: attr_value}}
-
-    """
-    if not isinstance(zn_type, list):
-        zn_type = [zn_type]
-    data = [x for x in data if x.zn_type in zn_type]
-    if return_with_type:
-        types_dict = {x.dvc_option: {} for x in data}
-        for entity in data:
-            if allow_none:
-                # avoid AttributeError
-                value = getattr(cls, entity.name, None)
-            else:
-                value = getattr(cls, entity.name)
-            types_dict[entity.dvc_option].update({entity.name: value})
-        return types_dict
-    if allow_none:
-        return {x.name: getattr(cls, x.name, None) for x in data}
-    # avoid AttributeError
-    return {x.name: getattr(cls, x.name) for x in data}
-
-
 def prepare_dvc_script(
     node_name,
     dvc_run_option: DVCRunOptions,
@@ -441,7 +391,7 @@ class GraphWriter:
         custom_args = []
         dependencies = []
         # Handle Parameter
-        params_list = filter_ZnTrackOption(
+        params_list = utils.helpers.filter_ZnTrackOption(
             data=self._descriptor_list, cls=self, zn_type=[utils.ZnTypes.PARAMS]
         )
         if len(params_list) > 0:

--- a/zntrack/metadata/base.py
+++ b/zntrack/metadata/base.py
@@ -3,7 +3,6 @@ from functools import partial
 from typing import Callable
 
 from zntrack import utils
-from zntrack.core.dvcgraph import filter_ZnTrackOption
 
 
 class MetaData(ABC):
@@ -51,7 +50,7 @@ class MetaData(ABC):
         try:
             metadata_attr, metadata = next(
                 iter(
-                    filter_ZnTrackOption(
+                    utils.helpers.filter_ZnTrackOption(
                         data=cls._descriptor_list,
                         cls=cls,
                         zn_type=utils.ZnTypes.METADATA,

--- a/zntrack/metadata/collectors.py
+++ b/zntrack/metadata/collectors.py
@@ -1,0 +1,17 @@
+import dataclasses
+
+
+@dataclasses.dataclass
+class NodeInfo:
+    author: str = None
+    license: str = None
+    short_description: str = None
+    long_description: str = None
+
+    def update_from_docstring(self, docstring: str):
+        self.long_description = docstring
+
+
+class RunInfo:
+    # TODO what is available via DVC already
+    start_time = None

--- a/zntrack/utils/helpers.py
+++ b/zntrack/utils/helpers.py
@@ -1,3 +1,8 @@
+import typing
+
+from zntrack.utils.structs import ZnTypes
+
+
 def isnode(node) -> bool:
     """Check if node contains a Node instance or class"""
     from zntrack.core.base import Node
@@ -11,3 +16,53 @@ def isnode(node) -> bool:
         except TypeError:
             pass
     return False
+
+
+def filter_ZnTrackOption(
+    data,
+    cls,
+    zn_type: typing.Union[ZnTypes, typing.List[ZnTypes]],
+    return_with_type=False,
+    allow_none: bool = False,
+) -> dict:
+    """Filter the descriptor instances by zn_type
+
+    Parameters
+    ----------
+    data: List[ZnTrackOption]
+        The ZnTrack options to query through
+    cls:
+        The instance the ZnTrack options are attached to
+    zn_type: str
+        The zn_type of the descriptors to gather
+    return_with_type: bool, default=False
+        return a dictionary with the Descriptor.dvc_option as keys
+    allow_none: bool, default=False
+        Use getattr(obj, name, None) instead of getattr(obj, name) to yield
+        None when an AttributeError occurs.
+
+    Returns
+    -------
+    dict:
+        either {attr_name: attr_value}
+        or
+        {descriptor.dvc_option: {attr_name: attr_value}}
+
+    """
+    if not isinstance(zn_type, (tuple, list)):
+        zn_type = [zn_type]
+    data = [x for x in data if x.zn_type in zn_type]
+    if return_with_type:
+        types_dict = {x.dvc_option: {} for x in data}
+        for entity in data:
+            if allow_none:
+                # avoid AttributeError
+                value = getattr(cls, entity.name, None)
+            else:
+                value = getattr(cls, entity.name)
+            types_dict[entity.dvc_option].update({entity.name: value})
+        return types_dict
+    if allow_none:
+        return {x.name: getattr(cls, x.name, None) for x in data}
+    # avoid AttributeError
+    return {x.name: getattr(cls, x.name) for x in data}


### PR DESCRIPTION
- fix #229 
- add `NodeInfo` and `RunInfo`

```py
# completely manual, default is no collection
class HelloWorld:
    """This is a Node"""
    run_info = zntrack.RunInfo()
    node_info = zntrack.NodeInfo(author="John Doe")
    
HelloWorld.load().run_info # RunInfo(start_time=2022-07-22T11:39:15)
HelloWorld.load().node_info # NodeInfo(author="John Doe", short_description="This is a Node")

# Works always
HelloWorld.zntrack.collect(zntrack.RunInfo) # RunInfo(start_time=2022-07-22T11:39:15)
```

# TODOs
- [ ] Documentation
- [ ] Docstrings
- [ ] fix RunInfo
- [ ] What happens when you try to set `self.run_info = ...` maybe protect it via a descriptor?
- [ ] should the dataclasses be frozen? Especially the NodeInfo one?