### PR TITLE
add `use_node_dir` to save results in the nodes directory

### DIFF
--- a/examples/docs/03_dependencies.ipynb
+++ b/examples/docs/03_dependencies.ipynb
@@ -3,7 +3,11 @@
   {
    "cell_type": "markdown",
    "id": "a781fb6d",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Dependencies\n",
     "\n",
@@ -27,7 +31,11 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "2e8ff1cd-7967-4c0e-8f77-32c8a0ecd94b",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from zntrack import Node, dvc, zn, config\n",
@@ -39,7 +47,11 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "9d8da8c5-f05d-4832-804c-0ad78cdfb851",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "config.nb_name = \"03_dependencies.ipynb\""
@@ -51,7 +63,10 @@
    "id": "a9842607-b54f-46bb-a708-269566dc0fbc",
    "metadata": {
     "nbsphinx": "hidden",
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -106,7 +121,10 @@
    "execution_count": 5,
    "id": "410e335c-c62b-4bda-932d-db97c3a84b2c",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -138,7 +156,11 @@
   {
    "cell_type": "markdown",
    "id": "e6f37308-a942-467d-94f6-1e6edfe7b317",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "We can now create the stages the usual way and look at the outcomes"
    ]
@@ -147,7 +169,11 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "00353190-29c3-4954-a9b5-aec358b35fa9",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -169,7 +195,11 @@
    "cell_type": "code",
    "execution_count": 7,
    "id": "a1928386-539a-4698-81a1-e68e843e1415",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -204,7 +234,11 @@
    "cell_type": "code",
    "execution_count": 8,
    "id": "7d235eca-8834-4e31-ad4e-51f83a80a625",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -224,7 +258,11 @@
   {
    "cell_type": "markdown",
    "id": "c07bbdc0-cbaf-4b5e-afce-47c07dfbd0f1",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## File dependencies\n",
     "The second approach is depending on files.\n",
@@ -246,13 +284,19 @@
    "cell_type": "code",
    "execution_count": 9,
    "id": "8c062896-ca2c-4a8f-a15c-294ee3866855",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# zntrack: break\n",
     "class WriteToFile(Node):\n",
     "    random_number: RandomNumber = zn.deps(RandomNumber)\n",
     "    file: Path = dvc.outs(Path(\"random_number.txt\"))\n",
+    "    # if you want the file to be created in nodes/<node_name>/<filename> you can pass use_node_dir=True.\n",
+    "    # This will update the file attribute and make it immutable.\n",
     "\n",
     "    def run(self):\n",
     "        self.file.write_text(str(self.random_number.number))\n",
@@ -282,7 +326,11 @@
    "cell_type": "code",
    "execution_count": 10,
    "id": "1eefb12a-65de-4c9b-a05a-b9827915b619",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -304,7 +352,11 @@
    "cell_type": "code",
    "execution_count": 11,
    "id": "883099de-6823-4000-9080-6f57b61a9bf9",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -343,7 +395,11 @@
    "cell_type": "code",
    "execution_count": 12,
    "id": "20944b0c-9c56-49fa-bff8-e77886d4e50f",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -397,7 +453,11 @@
   {
    "cell_type": "markdown",
    "id": "c0b8c97a-ab33-4ac4-9473-c203d88c0442",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "If we now look at our `dvc.yaml` we can see that for our Node dependencies we rely on the `outs/<node_name>.json` while for the file dependency it is directly connect to the passed file."
    ]
@@ -406,7 +466,11 @@
    "cell_type": "code",
    "execution_count": 14,
    "id": "32e1e993-ff99-4eb6-97db-ffc3ce834ca5",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {

--- a/poetry.lock
+++ b/poetry.lock
@@ -791,6 +791,17 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "execnet"
+version = "1.9.0"
+description = "execnet: rapid multi-Python deployment"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.extras]
+testing = ["pre-commit"]
+
+[[package]]
 name = "executing"
 version = "0.9.1"
 description = "Get the currently executing AST node of a frame, and other information"
@@ -1990,6 +2001,36 @@ tomli = ">=1.0.0"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
+name = "pytest-forked"
+version = "1.4.0"
+description = "run tests in isolated forked subprocesses"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+py = "*"
+pytest = ">=3.10"
+
+[[package]]
+name = "pytest-xdist"
+version = "2.5.0"
+description = "pytest xdist plugin for distributed testing and loop-on-failing modes"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+execnet = ">=1.1"
+pytest = ">=6.2.0"
+pytest-forked = "*"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
+
+[[package]]
 name = "python-benedict"
 version = "0.25.2"
 description = "python-benedict is a dict subclass with keylist/keypath support, normalized I/O operations (base64, csv, ini, json, pickle, plist, query-string, toml, xml, yaml) and many utilities... for humans, obviously."
@@ -2649,7 +2690,7 @@ python-versions = ">=3.8,<4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<4.0.0"
-content-hash = "1ba84beabe7d7e4a3253592f295688d0e0678b9c599bc76171400dc517ad3ac6"
+content-hash = "4c8639758673c0af887465b9a61cc1210cc31bf0b7b623a628935fd1e89a89de"
 
 [metadata.files]
 aiohttp = [
@@ -2937,6 +2978,10 @@ dvclive = []
 entrypoints = [
     {file = "entrypoints-0.4-py3-none-any.whl", hash = "sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f"},
     {file = "entrypoints-0.4.tar.gz", hash = "sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4"},
+]
+execnet = [
+    {file = "execnet-1.9.0-py2.py3-none-any.whl", hash = "sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142"},
+    {file = "execnet-1.9.0.tar.gz", hash = "sha256:8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5"},
 ]
 executing = [
     {file = "executing-0.9.1-py2.py3-none-any.whl", hash = "sha256:4ce4d6082d99361c0231fc31ac1a0f56979363cc6819de0b1410784f99e49105"},
@@ -3573,6 +3618,14 @@ pyrsistent = [
 pytest = [
     {file = "pytest-7.1.2-py3-none-any.whl", hash = "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c"},
     {file = "pytest-7.1.2.tar.gz", hash = "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"},
+]
+pytest-forked = [
+    {file = "pytest-forked-1.4.0.tar.gz", hash = "sha256:8b67587c8f98cbbadfdd804539ed5455b6ed03802203485dd2f53c1422d7440e"},
+    {file = "pytest_forked-1.4.0-py3-none-any.whl", hash = "sha256:bbbb6717efc886b9d64537b41fb1497cfaf3c9601276be8da2cccfea5a3c8ad8"},
+]
+pytest-xdist = [
+    {file = "pytest-xdist-2.5.0.tar.gz", hash = "sha256:4580deca3ff04ddb2ac53eba39d76cb5dd5edeac050cb6fbc768b0dd712b4edf"},
+    {file = "pytest_xdist-2.5.0-py3-none-any.whl", hash = "sha256:6fe5c74fec98906deb8f2d2b616b5c782022744978e7bd4695d39c8f42d0ce65"},
 ]
 python-benedict = [
     {file = "python-benedict-0.25.2.tar.gz", hash = "sha256:b6d95337049d35d3a9e81963940771415a2ef857e0f387736786f191feb1e747"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ flake8 = "^4.0.1"
 pre-commit = "^2.20.0"
 coverage = "^6.4"
 nbmake = "^1.3.3"
+pytest-xdist = "^2.5.0"
 
 [tool.poetry.urls]
 documentation = "https://zntrack.readthedocs.io"

--- a/zntrack/dvc/__init__.py
+++ b/zntrack/dvc/__init__.py
@@ -12,8 +12,7 @@ Examples
 import logging
 
 from zntrack import utils
-from zntrack.core.zntrackoption import ZnTrackOption
-from zntrack.dvc.custom_base import PlotsModifyOption
+from zntrack.dvc.custom_base import DVCOption, PlotsModifyOption
 
 log = logging.getLogger(__name__)
 
@@ -22,7 +21,7 @@ log = logging.getLogger(__name__)
 # detailed explanations on https://dvc.org/doc/command-reference/run#options
 
 
-class params(ZnTrackOption):
+class params(DVCOption):
     """Identify DVC option
 
     See https://dvc.org/doc/command-reference/run#options for more information
@@ -33,7 +32,7 @@ class params(ZnTrackOption):
     file = utils.Files.zntrack
 
 
-class deps(ZnTrackOption):
+class deps(DVCOption):
     """Identify DVC option
 
     See https://dvc.org/doc/command-reference/run#options for more information
@@ -53,7 +52,7 @@ class deps(ZnTrackOption):
         return value
 
 
-class outs(ZnTrackOption):
+class outs(DVCOption):
     """Identify DVC option
 
     See https://dvc.org/doc/command-reference/run#options for more information
@@ -64,7 +63,7 @@ class outs(ZnTrackOption):
     file = utils.Files.zntrack
 
 
-class checkpoints(ZnTrackOption):
+class checkpoints(DVCOption):
     """Identify DVC option
 
     See https://dvc.org/doc/command-reference/run#options for more information
@@ -75,7 +74,7 @@ class checkpoints(ZnTrackOption):
     file = utils.Files.zntrack
 
 
-class outs_no_cache(ZnTrackOption):
+class outs_no_cache(DVCOption):
     """Identify DVC option
 
     See https://dvc.org/doc/command-reference/run#options for more information
@@ -86,7 +85,7 @@ class outs_no_cache(ZnTrackOption):
     file = utils.Files.zntrack
 
 
-class outs_persistent(ZnTrackOption):
+class outs_persistent(DVCOption):
     """Identify DVC option
 
     See https://dvc.org/doc/command-reference/run#options for more information
@@ -97,7 +96,7 @@ class outs_persistent(ZnTrackOption):
     file = utils.Files.zntrack
 
 
-class metrics(ZnTrackOption):
+class metrics(DVCOption):
     """Identify DVC option
 
     See https://dvc.org/doc/command-reference/run#options for more information
@@ -108,7 +107,7 @@ class metrics(ZnTrackOption):
     file = utils.Files.zntrack
 
 
-class metrics_no_cache(ZnTrackOption):
+class metrics_no_cache(DVCOption):
     """Identify DVC option
 
     See https://dvc.org/doc/command-reference/run#options for more information
@@ -130,7 +129,7 @@ class plots(PlotsModifyOption):
     file = utils.Files.zntrack
 
 
-class plots_no_cache(ZnTrackOption):
+class plots_no_cache(PlotsModifyOption):
     """Identify DVC option
 
     See https://dvc.org/doc/command-reference/run#options for more information

--- a/zntrack/dvc/custom_base.py
+++ b/zntrack/dvc/custom_base.py
@@ -75,7 +75,11 @@ class DVCOption(ZnTrackOption):
 
         if instance is None:
             return self
-        elif (not instance.is_loaded) and (self.name not in instance.__dict__):
+        elif (
+            (not instance.is_loaded)
+            and (self.name not in instance.__dict__)
+            and self.use_node_dir
+        ):
             instance.__dict__[self.name] = update_iterable_paths(
                 copy.deepcopy(self.default_value),
                 pathlib.Path("nodes", instance.node_name),

--- a/zntrack/dvc/custom_base.py
+++ b/zntrack/dvc/custom_base.py
@@ -36,7 +36,19 @@ def update_iterable_paths(
 
 
 class DVCOption(ZnTrackOption):
-    def __init__(self, default_value=None, *, use_node_dir=None, **kwargs):
+    def __init__(self, default_value=None, *, use_node_dir=False, **kwargs):
+        """
+
+        Parameters
+        ----------
+        default_value
+        use_node_dir: bool (default=False)
+            Update all paths set for this DVCOption to point to nodes/<node_name>/filename
+            This allows to save files more easily outside the root directory and sort them
+            into the nodes directories without using self.node_name / file_name somewhere
+            in the init.
+        kwargs
+        """
         super().__init__(default_value=default_value, **kwargs)
         self.use_node_dir = use_node_dir
 

--- a/zntrack/utils/utils.py
+++ b/zntrack/utils/utils.py
@@ -86,12 +86,16 @@ def get_auto_init(fields: typing.List[str], super_init: typing.Callable):
 
     def auto_init(self, **kwargs):
         """Wrapper for the __init__"""
+        init_kwargs = {}
         for field in fields:
             try:
-                setattr(self, field, kwargs.pop(field))
+                init_kwargs[field] = kwargs.pop(field)
             except KeyError:
                 pass
         super_init(self, **kwargs)  # call the super_init explicitly instead of super
+        # must call the super_init first e.g. it is requried to set the node_name
+        for key, value in init_kwargs.items():
+            setattr(self, key, value)
 
         try:
             self.post_init()


### PR DESCRIPTION
- partially address #226
- allow dvc.<...> to store results in a dedicated node directory
- split `__get__`
- small bugfix with auto_init and super_init call