### PR TITLE
use `_` instead of `-` as delimiter

### DIFF
--- a/tests/integration_tests/test_zn_nodes2.py
+++ b/tests/integration_tests/test_zn_nodes2.py
@@ -108,9 +108,9 @@ def test_depth_graph(proj_path):
     assert node_4.params1.deps.param1 == "Lorem"
     assert node_4.params1.node.param2 == "Ipsum"
 
-    assert node_4.params1.node_name == "ExampleNode2-params1"
+    assert node_4.params1.node_name == "ExampleNode2_params1"
     assert node_4.params1.deps.node_name == "Node1"
-    assert node_4.params1.node.node_name == "ExampleNode2-params1-node"
+    assert node_4.params1.node.node_name == "ExampleNode2_params1_node"
 
 
 class NodeWithOuts(Node):
@@ -180,7 +180,7 @@ def test_ExampleUsesPlots(proj_path, node_name):
         node_with_plots=NodeWithPlots(factor=2.5), param=2.0, name=node_name
     )
     assert node.node_with_plots._is_attribute is True
-    assert node.node_with_plots.node_name == f"{node_name}-node_with_plots"
+    assert node.node_with_plots.node_name == f"{node_name}_node_with_plots"
     assert len(node.node_with_plots._descriptor_list) == 2
 
     node.write_graph()
@@ -191,7 +191,7 @@ def test_ExampleUsesPlots(proj_path, node_name):
     # Just checking if changing the parameters works as well
     with open("params.yaml", "r") as file:
         parameters = yaml.safe_load(file)
-    parameters[f"{node_name}-node_with_plots"]["factor"] = 1.0
+    parameters[f"{node_name}_node_with_plots"]["factor"] = 1.0
     with open("params.yaml", "a") as file:
         yaml.safe_dump(parameters, file)
 

--- a/zntrack/zn/nodes.py
+++ b/zntrack/zn/nodes.py
@@ -63,7 +63,7 @@ class Nodes(ZnTrackOption):
         value = super().__get__(instance, owner)
         if value is not None:
             value._is_attribute = True
-            value.node_name = f"{instance.node_name}-{self.name}"
+            value.node_name = f"{instance.node_name}_{self.name}"
         # value._is_attribute = True # value can be None
         value = utils.utils.load_node_dependency(value)  # use value = Cls.load()
         setattr(instance, self.name, value)


### PR DESCRIPTION
Hydra does not support
`dvc exp run --queue -S "my-param=10"`
but only
`dvc exp run --queue -S "my_param=10"`

so we replace it for `zn.Nodes`