### PR TITLE
improve `nwd`

### DIFF
--- a/tests/unit_tests/utils/test_nwd.py
+++ b/tests/unit_tests/utils/test_nwd.py
@@ -75,3 +75,13 @@ def test_replace_nwd_placeholder():
         replace_nwd_placeholder(5, node_working_directory="tmp")
 
     assert replace_nwd_placeholder(None, node_working_directory="tmp") is None
+
+
+def test_replace_nwd_single():
+    """Replace 'nwd' without __truediv__."""
+    assert replace_nwd_placeholder(
+        utils.nwd, pathlib.Path("node", "nodename")
+    ) == pathlib.Path("node", "nodename")
+    assert replace_nwd_placeholder(
+        "$nwd$", pathlib.Path("node", "nodename")
+    ) == pathlib.Path("node", "nodename")

--- a/zntrack/utils/nwd.py
+++ b/zntrack/utils/nwd.py
@@ -48,8 +48,10 @@ def _(path: None, node_working_directory) -> None:
 
 
 @replace_nwd_placeholder.register
-def _(path: str, node_working_directory) -> str:
+def _(path: str, node_working_directory) -> typing.Union[str, pathlib.Path]:
     """Main function to replace $nwd$ with 'nwd'."""
+    if path == nwd:
+        return node_working_directory
     return path.replace(nwd, pathlib.Path(node_working_directory).as_posix())
 
 


### PR DESCRIPTION
Allow `dvc.outs(zntrack.nwd)` directly without requiring `zntrack.nwd / <...>`