### PR TITLE
Add env

### DIFF
--- a/tests/integration/test_meta.py
+++ b/tests/integration/test_meta.py
@@ -15,10 +15,18 @@ class NodeWithMeta(zntrack.Node):
 class NodeWithEnv(zntrack.Node):
     OMP_NUM_THREADS = zntrack.meta.Environment("1")
 
+    result = zntrack.zn.outs()
+
     def run(self):
         import os
 
         assert os.environ["OMP_NUM_THREADS"] == self.OMP_NUM_THREADS
+
+        self.result = os.environ["OMP_NUM_THREADS"]
+
+
+class NodeWithEnvParam(NodeWithEnv):
+    OMP_NUM_THREADS = zntrack.meta.Environment("1", is_parameter=True)
 
 
 def test_NodeWithMeta(proj_path):
@@ -62,7 +70,24 @@ def test_CombinedNodeWithMeta(proj_path):
     assert CombinedNodeWithMeta.from_rev().output == "Hello there"
 
 
-def test_NodeWithEnv(proj_path):
+@pytest.mark.parametrize("cls", [NodeWithEnv, NodeWithEnvParam])
+def test_NodeWithEnv(proj_path, cls):
     with zntrack.Project() as proj:
-        NodeWithEnv()  # the actual test is inside the run method.
+        node = cls()  # the actual test is inside the run method.
     proj.run()
+
+    # check that the env variable is set correctly
+    node.load()
+    assert node.result == "1"
+
+    with proj:
+        node = cls(OMP_NUM_THREADS="2")  # the actual test is inside the run method.
+    proj.run()
+
+    node.load()
+    if cls == NodeWithEnvParam:
+        # Parameter will cause rerun and the result is changed
+        assert node.result == "2"
+    else:
+        # env is not a parameter and will not cause rerun
+        assert node.result == "1"

--- a/tests/integration/test_meta.py
+++ b/tests/integration/test_meta.py
@@ -12,6 +12,15 @@ class NodeWithMeta(zntrack.Node):
     title = zntrack.meta.Text("Test Node")
 
 
+class NodeWithEnv(zntrack.Node):
+    OMP_NUM_THREADS = zntrack.meta.Environment("1")
+
+    def run(self):
+        import os
+
+        assert os.environ["OMP_NUM_THREADS"] == self.OMP_NUM_THREADS
+
+
 def test_NodeWithMeta(proj_path):
     NodeWithMeta().write_graph()
 
@@ -51,3 +60,9 @@ def test_CombinedNodeWithMeta(proj_path):
     zntrack.utils.run_dvc_cmd(["repro", "-f"])
     # Forcing rerun should use the updated meta keyword.
     assert CombinedNodeWithMeta.from_rev().output == "Hello there"
+
+
+def test_NodeWithEnv(proj_path):
+    with zntrack.Project() as proj:
+        NodeWithEnv()  # the actual test is inside the run method.
+    proj.run()

--- a/zntrack/cli/__init__.py
+++ b/zntrack/cli/__init__.py
@@ -1,10 +1,12 @@
 """The ZnTrack CLI."""
 import importlib.metadata
+import os
 import pathlib
 import sys
 import uuid
 
 import typer
+import yaml
 
 from zntrack import Node, utils
 
@@ -34,6 +36,12 @@ def run(node: str, name: str = None, hash_only: bool = False) -> None:
 
     Use as 'zntrack run module.Node --name node_name'.
     """
+    env_file = pathlib.Path("env.yaml")
+    if env_file.exists():
+        env = yaml.safe_load(env_file.read_text())
+        for key, value in env.get(name, {}).items():
+            os.environ[key] = value
+
     sys.path.append(pathlib.Path.cwd().as_posix())
 
     package_and_module, cls = node.rsplit(".", 1)

--- a/zntrack/core/node.py
+++ b/zntrack/core/node.py
@@ -113,6 +113,7 @@ class Node(zninit.ZnInit, znflow.Node):
             fields.zn.Params,
             fields.zn.Dependency,
             fields.meta.Text,
+            fields.meta.Environment,
             fields.dvc.DVCOption,
             _NameDescriptor,
         ]

--- a/zntrack/fields/meta/__init__.py
+++ b/zntrack/fields/meta/__init__.py
@@ -37,3 +37,39 @@ class Text(Field):
     def get_stage_add_argument(self, instance) -> typing.List[tuple]:
         """Get the dvc command for this field."""
         return []
+
+
+class Environment(Field):
+    """Environment variables to export."""
+
+    dvc_option: str = None
+    group = FieldGroup.PARAMETER
+
+    def get_affected_files(self, instance) -> list:
+        """No affect files"""
+        return []
+
+    def save(self, instance):
+        """Save the field to disk."""
+        file = pathlib.Path("env.yaml")
+        try:
+            context = yaml.safe_load(file.read_text())
+        except FileNotFoundError:
+            context = {}
+
+        node_context = context.get(instance.name, {})
+        value = getattr(instance, self.name)
+        if not isinstance(value, str):
+            raise ValueError(f"Environment value must be a string, not {type(value)}")
+        node_context[self.name] = value
+        context[instance.name] = node_context
+        file.write_text(yaml.safe_dump(context))
+
+    def get_data(self, instance: "Node") -> any:
+        """Get the value of the field from the file."""
+        env_dict = yaml.safe_load(instance.state.get_file_system().read_text("env.yaml"))
+        return env_dict.get(instance.name, {}).get(self.name, None)
+
+    def get_stage_add_argument(self, instance) -> typing.List[tuple]:
+        """Get the dvc command for this field."""
+        return []

--- a/zntrack/fields/meta/__init__.py
+++ b/zntrack/fields/meta/__init__.py
@@ -46,7 +46,7 @@ class Environment(Field):
     group = FieldGroup.PARAMETER
 
     def get_affected_files(self, instance) -> list:
-        """No affect files"""
+        """There are no affect files."""
         return []
 
     def save(self, instance):

--- a/zntrack/fields/meta/__init__.py
+++ b/zntrack/fields/meta/__init__.py
@@ -45,6 +45,11 @@ class Environment(Field):
     dvc_option: str = None
     group = FieldGroup.PARAMETER
 
+    def __init__(self, *args, is_parameter: bool = False, **kwargs):
+        """Initialize the field."""
+        self.is_parameter = is_parameter
+        super().__init__(*args, **kwargs)
+
     def get_affected_files(self, instance) -> list:
         """There are no affect files."""
         return []
@@ -72,4 +77,6 @@ class Environment(Field):
 
     def get_stage_add_argument(self, instance) -> typing.List[tuple]:
         """Get the dvc command for this field."""
+        if self.is_parameter:
+            return [("--params", f"env.yaml:{instance.name}.{self.name}")]
         return []


### PR DESCRIPTION
- fix #88 

- [x] have environmental fields that are parameters? Still use `env.yaml` and then do `dvc -params env.yaml:<nodename>.<desc_name>`