### PR TITLE
Improve `zntrack.meta.Environement`

### DIFF
--- a/tests/integration/test_meta.py
+++ b/tests/integration/test_meta.py
@@ -122,3 +122,21 @@ def test_NodeWithEnv(proj_path, cls):
     else:
         # env is not a parameter and will not cause rerun
         assert node.result == "1"
+
+
+class EnvAsDict(zntrack.Node):
+    env: dict = zntrack.meta.Environment({"OMP_NUM_THREADS": "1"})
+    SPECIAL_ENV = zntrack.meta.Environment()
+
+    def run(self):
+        import os
+
+        assert self.env["OMP_NUM_THREADS"] == "1"
+        assert os.environ["OMP_NUM_THREADS"] == self.env["OMP_NUM_THREADS"]
+        assert os.environ["ZNTRACK_EXAMPLE"] == "1"
+
+
+def test_EnvAsDict(proj_path):
+    with zntrack.Project() as proj:
+        _ = EnvAsDict(SPECIAL_ENV="25")  # the actual test is inside the run method.
+    proj.run(environment={"ZNTRACK_EXAMPLE": "1"})

--- a/tests/integration/test_meta.py
+++ b/tests/integration/test_meta.py
@@ -134,6 +134,7 @@ class EnvAsDict(zntrack.Node):
         assert self.env["OMP_NUM_THREADS"] == "1"
         assert os.environ["OMP_NUM_THREADS"] == self.env["OMP_NUM_THREADS"]
         assert os.environ["ZNTRACK_EXAMPLE"] == "1"
+        assert os.environ["SPECIAL_ENV"] == "25"
 
 
 def test_EnvAsDict(proj_path):

--- a/tests/integration/test_meta.py
+++ b/tests/integration/test_meta.py
@@ -20,7 +20,9 @@ class NodeWithEnv(zntrack.Node):
     def run(self):
         import os
 
-        assert os.environ["OMP_NUM_THREADS"] == self.OMP_NUM_THREADS
+        assert (
+            os.environ["OMP_NUM_THREADS"] == self.OMP_NUM_THREADS
+        ), f'{os.environ["OMP_NUM_THREADS"]} != {self.OMP_NUM_THREADS}'
 
         self.result = os.environ["OMP_NUM_THREADS"]
 
@@ -36,8 +38,21 @@ class NodeWithEnvNone(zntrack.Node):
         assert "OMP_NUM_THREADS" not in os.environ
 
 
+class AssertGlobalEnv(zntrack.Node):
+    def run(self):
+        import os
+
+        assert os.environ["ZNTRACK_EXAMPLE"] == "1"
+
+
 class NodeWithEnvParam(NodeWithEnv):
     OMP_NUM_THREADS = zntrack.meta.Environment("1", is_parameter=True)
+
+
+def test_GlobalEnv(proj_path):
+    with zntrack.Project() as proj:
+        _ = AssertGlobalEnv()
+    proj.run(environment={"ZNTRACK_EXAMPLE": "1"})
 
 
 @pytest.mark.parametrize("eager", [True, False])

--- a/zntrack/cli/__init__.py
+++ b/zntrack/cli/__init__.py
@@ -55,9 +55,7 @@ def run(node: str, name: str = None, hash_only: bool = False) -> None:
     env_file = pathlib.Path("env.yaml")
     if env_file.exists():
         env = yaml.safe_load(env_file.read_text())
-        for key, value in env.get("global", {}).items():
-            if value is not None:
-                os.environ[key] = value
+        os.environ.update(env.get("global", {}))
 
         for key, value in env.get("stages", {}).get(name, {}).items():
             if isinstance(value, str):

--- a/zntrack/cli/__init__.py
+++ b/zntrack/cli/__init__.py
@@ -55,7 +55,11 @@ def run(node: str, name: str = None, hash_only: bool = False) -> None:
     env_file = pathlib.Path("env.yaml")
     if env_file.exists():
         env = yaml.safe_load(env_file.read_text())
-        for key, value in env.get(name, {}).items():
+        for key, value in env.get("global", {}).items():
+            if value is not None:
+                os.environ[key] = value
+
+        for key, value in env.get("stages", {}).get(name, {}).items():
             if value is not None:
                 os.environ[key] = value
 

--- a/zntrack/cli/__init__.py
+++ b/zntrack/cli/__init__.py
@@ -60,7 +60,7 @@ def run(node: str, name: str = None, hash_only: bool = False) -> None:
                 os.environ[key] = value
 
         for key, value in env.get("stages", {}).get(name, {}).items():
-            if value is not None:
+            if isinstance(value, str):
                 os.environ[key] = value
 
     sys.path.append(pathlib.Path.cwd().as_posix())

--- a/zntrack/cli/__init__.py
+++ b/zntrack/cli/__init__.py
@@ -60,6 +60,12 @@ def run(node: str, name: str = None, hash_only: bool = False) -> None:
         for key, value in env.get("stages", {}).get(name, {}).items():
             if isinstance(value, str):
                 os.environ[key] = value
+            elif isinstance(value, dict):
+                os.environ.update(value)
+            elif value is None:
+                pass
+            else:
+                raise ValueError(f"Unknown value for env variable {key}: {value}")
 
     sys.path.append(pathlib.Path.cwd().as_posix())
 

--- a/zntrack/fields/meta/__init__.py
+++ b/zntrack/fields/meta/__init__.py
@@ -84,10 +84,15 @@ class Environment(Field):
 
         node_context = stages.get(instance.name, {})
         value = getattr(instance, self.name)
-        if not isinstance(value, str) and value is not None:
-            raise ValueError(f"Environment value must be a string, not {type(value)}")
-        node_context[self.name] = value
-        stages[instance.name] = node_context
+        if isinstance(value, (str, dict)):
+            node_context[self.name] = value
+            stages[instance.name] = node_context
+        elif value is None:
+            return
+        else:
+            raise ValueError(
+                f"Environment value must be a string or dict, not {type(value)}"
+            )
 
         context["stages"] = stages
         file.write_text(yaml.safe_dump(context))

--- a/zntrack/fields/meta/__init__.py
+++ b/zntrack/fields/meta/__init__.py
@@ -95,10 +95,10 @@ class Environment(Field):
     def get_data(self, instance: "Node") -> any:
         """Get the value of the field from the file."""
         env_dict = yaml.safe_load(instance.state.fs.read_text("env.yaml"))
-        return env_dict.get(instance.name, {}).get(self.name, None)
+        return env_dict.get("stages", {}).get(instance.name, {}).get(self.name, None)
 
     def get_stage_add_argument(self, instance) -> typing.List[tuple]:
         """Get the dvc command for this field."""
         if self.is_parameter:
-            return [("--params", f"env.yaml:{instance.name}.{self.name}")]
+            return [("--params", f"env.yaml:stages.{instance.name}.{self.name}")]
         return []

--- a/zntrack/fields/meta/__init__.py
+++ b/zntrack/fields/meta/__init__.py
@@ -79,12 +79,17 @@ class Environment(Field):
         except FileNotFoundError:
             context = {}
 
-        node_context = context.get(instance.name, {})
+        stages = context.get("stages", {})
+        # TODO: when to reset the environment variables?
+
+        node_context = stages.get(instance.name, {})
         value = getattr(instance, self.name)
         if not isinstance(value, str) and value is not None:
             raise ValueError(f"Environment value must be a string, not {type(value)}")
         node_context[self.name] = value
-        context[instance.name] = node_context
+        stages[instance.name] = node_context
+
+        context["stages"] = stages
         file.write_text(yaml.safe_dump(context))
 
     def get_data(self, instance: "Node") -> any:

--- a/zntrack/utils/config.py
+++ b/zntrack/utils/config.py
@@ -49,7 +49,7 @@ class Config:
     interpreter: typing.Union[str, Path] = Path(sys.executable).name
     dvc_api: bool = True
     disable_operating_directory: bool = False
-    _log_level: int = dataclasses.field(default=logging.INFO, init=False, repr=True)
+    _log_level: int = dataclasses.field(default=logging.DEBUG, init=False, repr=True)
 
     @property
     def log_level(self):

--- a/zntrack/utils/config.py
+++ b/zntrack/utils/config.py
@@ -49,7 +49,7 @@ class Config:
     interpreter: typing.Union[str, Path] = Path(sys.executable).name
     dvc_api: bool = True
     disable_operating_directory: bool = False
-    _log_level: int = dataclasses.field(default=logging.DEBUG, init=False, repr=True)
+    _log_level: int = dataclasses.field(default=logging.INFO, init=False, repr=True)
 
     @property
     def log_level(self):


### PR DESCRIPTION
The `env.yaml` has been extended:

```yaml
global:  # support for global envs on all stages
  ZNTRACK_EXAMPLE: '1'
stages:
  EnvAsDict:
    SPECIAL_ENV: '25'
    env:  # you can group envs now
      OMP_NUM_THREADS: '1'
```

- support for groups `zntrack.meta.Environement: dict`
- support for global `project.run(environment: dict = ...)`