### PR TITLE
allow _module_ to define custom import path

### DIFF
--- a/tests/integration/test_misc.py
+++ b/tests/integration/test_misc.py
@@ -50,3 +50,19 @@ def test_SwitchNode(proj_path):
 
     params = yaml.safe_load(pathlib.Path("params.yaml").read_text())
     assert params["Node"] == {"params2": 2}
+
+
+class CustomModule(zntrack.Node):
+    _module_ = "zntrack.nodes"
+
+
+def test_CustomModule(proj_path):
+    with zntrack.Project() as proj:
+        CustomModule()
+    proj.run(repro=False)
+
+    dvc = yaml.safe_load(pathlib.Path("dvc.yaml").read_text())
+    assert (
+        dvc["stages"]["CustomModule"]["cmd"]
+        == "zntrack run zntrack.nodes.CustomModule --name CustomModule"
+    )

--- a/zntrack/utils/__init__.py
+++ b/zntrack/utils/__init__.py
@@ -58,6 +58,8 @@ def module_handler(obj) -> str:
         except AttributeError:
             return f"{config.nb_class_path}.{obj.__class__.__name__}"
     if obj.__module__ != "__main__":
+        if hasattr(obj, "_module_"):  # allow module override
+            return obj._module_
         return obj.__module__
     if pathlib.Path(sys.argv[0]).stem == "ipykernel_launcher":
         # special case for e.g. testing


### PR DESCRIPTION
Allow

```python
class CustomModule(zntrack.Node):
    _module_ = "zntrack.nodes"
```

to define the `__module__` to import from, altough the Node might be defined somewhere else.
This is useful if:
- your package has a lot of Nodes in differente modules, to organize them
- you want to be able to rename the modules
- you have one import for all nodes `package.nodes.<my_node>`