### PR TITLE
Add `Project(git_only_repo: bool)`

### DIFF
--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -1,6 +1,7 @@
 import json
 import pathlib
 
+import git
 import pytest
 
 import zntrack
@@ -424,3 +425,23 @@ def test_nested_groups(proj_path):
     assert node_1.outputs == "Lorem Ipsum"
     assert node_2.outputs == "Dolor Sit"
     assert node_3.outputs == "Amet Consectetur"
+
+
+@pytest.mark.parametrize("git_only_repo", [True, False])
+def test_git_only_repo(proj_path, git_only_repo):
+    with zntrack.Project(git_only_repo=git_only_repo) as project:
+        WriteIO(inputs="Lorem Ipsum")
+
+    project.run()
+
+    # commit everything
+    repo = git.Repo()
+    repo.git.add(".")
+    repo.index.commit("initial commit")
+
+    if git_only_repo:
+        # check if node-meta.json is in the repo index
+        assert ("nodes/WriteIO/node-meta.json", 0) in repo.index.entries.keys()
+    else:
+        # check if node-meta.json is not in the repo index
+        assert ("nodes/WriteIO/node-meta.json", 0) not in repo.index.entries.keys()

--- a/tests/integration/test_zn_nodes2.py
+++ b/tests/integration/test_zn_nodes2.py
@@ -61,9 +61,10 @@ def test_ExampleNode(proj_path, eager):
         assert node.params2.name == "ExampleNode_params2"
 
 
+@pytest.mark.parametrize("git_only_repo", [True, False])
 @pytest.mark.parametrize("eager", [True, False])
-def test_ExampleNodeLst(proj_path, eager):
-    project = Project()
+def test_ExampleNodeLst(proj_path, eager, git_only_repo):
+    project = Project(git_only_repo=git_only_repo)
     parameter_1 = NodeViaParams(param1=1)
     parameter_2 = NodeViaParams(param1=10)
 

--- a/zntrack/core/node.py
+++ b/zntrack/core/node.py
@@ -337,7 +337,10 @@ def get_dvc_cmd(
     for field_cmd in set(field_cmds):
         cmd += list(field_cmd)
 
-    cmd += ["--metrics-no-cache", f"{(node.nwd /'node-meta.json').as_posix()}"]
+    if node._graph_.project.git_only_repo:
+        cmd += ["--metrics-no-cache", f"{(node.nwd /'node-meta.json').as_posix()}"]
+    else:
+        cmd += ["--outs", f"{(node.nwd /'node-meta.json').as_posix()}"]
 
     module = module_handler(node.__class__)
     cmd += [f"zntrack run {module}.{node.__class__.__name__} --name {node.name}"]

--- a/zntrack/core/node.py
+++ b/zntrack/core/node.py
@@ -292,7 +292,7 @@ class Node(zninit.ZnInit, znflow.Node):
     )
     def write_graph(self, run: bool = False, **kwargs):
         """Write the graph to dvc.yaml."""
-        cmd = get_dvc_cmd(self, **kwargs)
+        cmd = get_dvc_cmd(self, git_only_repo=True, **kwargs)
         for x in cmd:
             run_dvc_cmd(x)
         self.save()
@@ -303,6 +303,7 @@ class Node(zninit.ZnInit, znflow.Node):
 
 def get_dvc_cmd(
     node: Node,
+    git_only_repo: bool,
     quiet: bool = False,
     verbose: bool = False,
     force: bool = True,
@@ -332,12 +333,12 @@ def get_dvc_cmd(
     field_cmds = []
     for attr in zninit.get_descriptors(Field, self=node):
         field_cmds += attr.get_stage_add_argument(node)
-        optionals += attr.get_optional_dvc_cmd(node)
+        optionals += attr.get_optional_dvc_cmd(node, git_only_repo=git_only_repo)
 
     for field_cmd in set(field_cmds):
         cmd += list(field_cmd)
 
-    if node._graph_.project.git_only_repo:
+    if git_only_repo:
         cmd += ["--metrics-no-cache", f"{(node.nwd /'node-meta.json').as_posix()}"]
     else:
         cmd += ["--outs", f"{(node.nwd /'node-meta.json').as_posix()}"]

--- a/zntrack/core/node.py
+++ b/zntrack/core/node.py
@@ -245,13 +245,14 @@ class Node(zninit.ZnInit, znflow.Node):
         except KeyError as err:
             raise exceptions.NodeNotAvailableError(self) from err
 
-        with contextlib.suppress(FileNotFoundError):
-            # If the uuid is available, we can assume that all data for
-            #  this Node is available.
-            with self.state.fs.open(self.nwd / "node-meta.json") as f:
-                node_meta = json.load(f)
-                self._uuid = uuid.UUID(node_meta["uuid"])
-                self.state.results = NodeStatusResults.AVAILABLE
+        if results:
+            with contextlib.suppress(FileNotFoundError):
+                # If the uuid is available, we can assume that all data for
+                #  this Node is available.
+                with self.state.fs.open(self.nwd / "node-meta.json") as f:
+                    node_meta = json.load(f)
+                    self._uuid = uuid.UUID(node_meta["uuid"])
+                    self.state.results = NodeStatusResults.AVAILABLE
         # TODO: documentation about _post_init and _post_load_ and when they are called
         self._post_load_()
 

--- a/zntrack/fields/field.py
+++ b/zntrack/fields/field.py
@@ -108,7 +108,9 @@ class Field(zninit.Descriptor, abc.ABC):
             for x in self.get_files(instance)
         ]
 
-    def get_optional_dvc_cmd(self, instance: "Node") -> typing.List[typing.List[str]]:
+    def get_optional_dvc_cmd(
+        self, instance: "Node", git_only_repo: bool
+    ) -> typing.List[typing.List[str]]:
         """Get optional dvc commands that will be executed beside the main dvc command.
 
         This could be 'plots modify ...' or 'stage add --name node_helper'
@@ -117,6 +119,8 @@ class Field(zninit.Descriptor, abc.ABC):
         ----------
         instance : Node
             The Node instance to get the optional dvc commands for.
+        git_only_repo : bool
+            Whether the repo is a git only repo or has a dvc remote.
 
         Returns
         -------
@@ -295,7 +299,9 @@ class PlotsMixin(Field):
         dvc_config["plots"] = plots
         dvc_file.write_text(yaml.dump(dvc_config))
 
-    def get_optional_dvc_cmd(self, instance: "Node") -> typing.List[typing.List[str]]:
+    def get_optional_dvc_cmd(
+        self, instance: "Node", git_only_repo: bool
+    ) -> typing.List[typing.List[str]]:
         """Add 'dvc plots modify' to this option."""
         if not self.use_global_plots:
             cmds = []

--- a/zntrack/fields/zn/__init__.py
+++ b/zntrack/fields/zn/__init__.py
@@ -535,7 +535,7 @@ class NodeField(Dependency):
                 "--name",
                 name,
                 "--force",
-                "--metrics-no-cache",
+                "--metrics-no-cache" if node._graph_.project.git_only_repo else "--outs",
                 (nwd / "node-meta.json").as_posix(),  # HOW DO I MOVE THIS TO GROUP ?
                 "--params",
                 f"zntrack.json:{instance.name}.{self.name}",

--- a/zntrack/fields/zn/__init__.py
+++ b/zntrack/fields/zn/__init__.py
@@ -508,7 +508,9 @@ class NodeField(Dependency):
         else:
             return instance.nwd.parent / name
 
-    def get_optional_dvc_cmd(self, instance: "Node") -> typing.List[list]:
+    def get_optional_dvc_cmd(
+        self, instance: "Node", git_only_repo: bool
+    ) -> typing.List[list]:
         """Get the dvc command for this field."""
         nodes = getattr(instance, self.name)
         if nodes is None:
@@ -535,7 +537,7 @@ class NodeField(Dependency):
                 "--name",
                 name,
                 "--force",
-                "--metrics-no-cache" if node._graph_.project.git_only_repo else "--outs",
+                "--metrics-no-cache" if git_only_repo else "--outs",
                 (nwd / "node-meta.json").as_posix(),  # HOW DO I MOVE THIS TO GROUP ?
                 "--params",
                 f"zntrack.json:{instance.name}.{self.name}",

--- a/zntrack/project/zntrack_project.py
+++ b/zntrack/project/zntrack_project.py
@@ -71,6 +71,13 @@ class Project:
     automatic_node_names : bool, default = False
         If True, automatically add a number to the node name if the name is already
             used in the graph.
+    git_only_repo : bool, default = False
+        The DVC graph relies on file outputs for connecting stages.
+        ZnTrack will use a '--outs' for each stage by default.
+        This will require a DVC remote to be setup.
+        If a project is not used with a DVC remote and strictly GIT,
+        this can be set to True and instead '--metrics-no-cache' will be used.
+        Metrics is used instead of 'outs-no-cache' to keep the DVC run cache.
     force : bool, default = False
         overwrite existing nodes.
     """
@@ -79,6 +86,7 @@ class Project:
     initialize: bool = True
     remove_existing_graph: bool = False
     automatic_node_names: bool = False
+    git_only_repo: bool = False
     force: bool = False
 
     _groups: list = dataclasses.field(default_factory=list, init=False, repr=False)

--- a/zntrack/project/zntrack_project.py
+++ b/zntrack/project/zntrack_project.py
@@ -238,7 +238,9 @@ class Project:
                 node.state.loaded = True
             else:
                 log.info(f"Adding node {node}")
-                cmd = get_dvc_cmd(node, **optional.get(node.name, {}))
+                cmd = get_dvc_cmd(
+                    node, git_only_repo=self.git_only_repo, **optional.get(node.name, {})
+                )
                 for x in cmd:
                     run_dvc_cmd(x)
                 node.save(results=False)

--- a/zntrack/project/zntrack_project.py
+++ b/zntrack/project/zntrack_project.py
@@ -71,13 +71,12 @@ class Project:
     automatic_node_names : bool, default = False
         If True, automatically add a number to the node name if the name is already
             used in the graph.
-    git_only_repo : bool, default = False
+    git_only_repo : bool, default = True
         The DVC graph relies on file outputs for connecting stages.
-        ZnTrack will use a '--outs' for each stage by default.
+        ZnTrack will use a '--metrics-no-cache' file output for each stage by default.
+        Contrary to '--outs-no-cache', this will keep the DVC run cache available.
+        If a project has a DVC remote available, '--outs' can be used instead.
         This will require a DVC remote to be setup.
-        If a project is not used with a DVC remote and strictly GIT,
-        this can be set to True and instead '--metrics-no-cache' will be used.
-        Metrics is used instead of 'outs-no-cache' to keep the DVC run cache.
     force : bool, default = False
         overwrite existing nodes.
     """
@@ -86,7 +85,7 @@ class Project:
     initialize: bool = True
     remove_existing_graph: bool = False
     automatic_node_names: bool = False
-    git_only_repo: bool = False
+    git_only_repo: bool = True
     force: bool = False
 
     _groups: list = dataclasses.field(default_factory=list, init=False, repr=False)


### PR DESCRIPTION
This option integrated:

```
The DVC graph relies on file outputs for connecting stages.
ZnTrack will use a '--outs' for each stage by default.
This will require a DVC remote to be setup.
If a project is not used with a DVC remote and strictly GIT,
this can be set to True and instead '--metrics-no-cache' will be used.
Metrics is used instead of 'outs-no-cache' to keep the DVC run cache.
```

## TODO
- [ ] check if removing metrics still is different from removing an dvc tracked output. Run a command and then interrupt it. Then try checkout.
- [x] check that the default outs is `--metrics-no-cache` with ´node-meta.json´