### PR TITLE
add example module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ multi_line_output = 3
 relative_files = true
 branch = true
 # omit the tests themselves
-omit = ["*/tests/*", "*/tmp/*", "*/interface/*"]
+omit = ["*/tests/*", "*/tmp/*", "*/interface/*", "zntrack/examples/*"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -4,6 +4,7 @@ import pathlib
 import pytest
 from typer.testing import CliRunner
 
+import zntrack.examples
 from zntrack import Node, NodeConfig, nodify, zn
 from zntrack.cli import app
 
@@ -66,14 +67,6 @@ def test_init_force(tmp_path, runner, force):
         assert not pathlib.Path("README.md").exists()
 
 
-class InputsToOutputs(Node):
-    inputs = zn.params()
-    outputs = zn.outs()
-
-    def run(self):
-        self.outputs = self.inputs
-
-
 @nodify(outs="test.txt", params={"text": "Lorem Ipsum"})
 def example_func(cfg: NodeConfig) -> NodeConfig:
     out_file = pathlib.Path(cfg.outs)
@@ -82,13 +75,13 @@ def example_func(cfg: NodeConfig) -> NodeConfig:
 
 
 def test_run(proj_path, runner):
-    node = InputsToOutputs(inputs=15)
+    node = zntrack.examples.ParamsToOuts(params=15)
     node.write_graph()
-    result = runner.invoke(app, ["run", "test_cli.InputsToOutputs"])
+    result = runner.invoke(app, ["run", "zntrack.examples.ParamsToOuts"])
     assert result.exit_code == 0
 
     node.load()
-    assert node.outputs == 15
+    assert node.outs == 15
 
 
 def test_run_nodify(proj_path, runner):
@@ -99,10 +92,12 @@ def test_run_nodify(proj_path, runner):
 
 
 def test_run_w_name(proj_path, runner):
-    node = InputsToOutputs(inputs=15, name="TestNode")
+    node = zntrack.examples.ParamsToOuts(params=15, name="TestNode")
     node.write_graph()
-    result = runner.invoke(app, ["run", "test_cli.InputsToOutputs", "--name", "TestNode"])
+    result = runner.invoke(
+        app, ["run", "zntrack.examples.ParamsToOuts", "--name", "TestNode"]
+    )
     assert result.exit_code == 0
 
     node.load()
-    assert node.outputs == 15
+    assert node.outs == 15

--- a/tests/integration/test_external_experiments.py
+++ b/tests/integration/test_external_experiments.py
@@ -1,29 +1,13 @@
 import git
 import pytest
 
-import zntrack
-
-
-class SaveNumber(zntrack.Node):
-    inputs = zntrack.zn.params()
-    outputs = zntrack.zn.outs()
-
-    def run(self):
-        self.outputs = self.inputs
-
-
-class AddNumbers(zntrack.Node):
-    numbers: list = zntrack.zn.deps()
-    sum: int = zntrack.zn.outs()
-
-    def run(self):
-        self.sum = sum(x.outputs for x in self.numbers)
+import zntrack.examples
 
 
 @pytest.mark.parametrize("automatic_node_names", [True, False])
 def test_multiple_experiments(proj_path, automatic_node_names):
     with zntrack.Project(automatic_node_names=automatic_node_names) as proj:
-        node = SaveNumber(1)
+        node = zntrack.examples.ParamsToOuts(1)
     proj.build()
     proj.repro()
 
@@ -37,15 +21,15 @@ def test_multiple_experiments(proj_path, automatic_node_names):
 
     for exp in range(5):
         with proj.create_experiment(f"exp{exp}", queue=False):
-            node.inputs = exp
+            node.params = exp
 
-    nodes = [SaveNumber.from_rev(rev=f"exp{exp}") for exp in range(5)]
+    nodes = [zntrack.examples.ParamsToOuts.from_rev(rev=f"exp{exp}") for exp in range(5)]
     for idx, node in enumerate(nodes):
-        assert node.outputs == idx
+        assert node.outs == idx
         assert node._external_
 
     with proj:  # test with / without automatic node names
-        node2 = AddNumbers(nodes)
+        node2 = zntrack.examples.AddNumbers(nodes)
 
     proj.run()
     node2.load()

--- a/tests/integration/test_external_experiments.py
+++ b/tests/integration/test_external_experiments.py
@@ -29,7 +29,7 @@ def test_multiple_experiments(proj_path, automatic_node_names):
         assert node._external_
 
     with proj:  # test with / without automatic node names
-        node2 = zntrack.examples.AddNumbers(nodes)
+        node2 = zntrack.examples.AddNodeNumbers(nodes)
 
     proj.run()
     node2.load()

--- a/tests/integration/test_from_rev.py
+++ b/tests/integration/test_from_rev.py
@@ -3,16 +3,8 @@ import uuid
 import dvc.scm
 import pytest
 
-import zntrack
+import zntrack.examples
 from zntrack.utils import NodeStatusResults
-
-
-class AddOne(zntrack.Node):
-    number: int = zntrack.zn.deps()
-    outs: int = zntrack.zn.outs()
-
-    def run(self) -> None:
-        self.outs = self.number + 1
 
 
 def test_module_not_installed():
@@ -65,7 +57,7 @@ def test_connect_from_remote(proj_path):
     assert node_b.random_number == 126
 
     with zntrack.Project() as project:
-        node = AddOne(number=node_a.random_number)
+        node = zntrack.examples.AddOne(number=node_a.random_number)
 
     project.run()
     node.load()
@@ -73,7 +65,7 @@ def test_connect_from_remote(proj_path):
     assert node.outs == node_a.random_number + 1
 
     with zntrack.Project() as project:
-        node = AddOne(number=node_b.random_number)
+        node = zntrack.examples.AddOne(number=node_b.random_number)
 
     project.run()
     # We can not use node.load() here and build again,
@@ -94,8 +86,8 @@ def test_two_nodes_connect_external(proj_path):
     )
 
     with zntrack.Project(automatic_node_names=True) as project:
-        node1 = AddOne(number=node_a.random_number)
-        node2 = AddOne(number=node_a.random_number)
+        node1 = zntrack.examples.AddOne(number=node_a.random_number)
+        node2 = zntrack.examples.AddOne(number=node_a.random_number)
 
     project.run()
 

--- a/tests/integration/test_lazy_loading.py
+++ b/tests/integration/test_lazy_loading.py
@@ -28,7 +28,7 @@ def test_CollectOutputs(proj_path, lazy, eager):
         with zntrack.Project() as project:
             a = zntrack.examples.ParamsToOuts(params=17, name="a")
             b = zntrack.examples.ParamsToOuts(params=42, name="b")
-            node = zntrack.examples.AddNumbers(numbers=[a, b])
+            node = zntrack.examples.AddNodeNumbers(numbers=[a, b])
         project.run(eager=eager)
 
         if not eager:

--- a/tests/integration/test_lazy_loading.py
+++ b/tests/integration/test_lazy_loading.py
@@ -1,25 +1,7 @@
-import dataclasses
-
 import pytest
 
-import zntrack
+import zntrack.examples
 from zntrack.utils import LazyOption
-
-
-class WriteOutput(zntrack.Node):
-    value = zntrack.zn.params()
-    output = zntrack.zn.outs()
-
-    def run(self) -> None:
-        self.output = self.value
-
-
-class CollectOutputs(zntrack.Node):
-    nodes = zntrack.zn.deps()
-    output = zntrack.zn.outs()
-
-    def run(self) -> None:
-        self.output = sum(x.output for x in self.nodes)
 
 
 @pytest.mark.parametrize("eager", [True, False])
@@ -27,15 +9,15 @@ class CollectOutputs(zntrack.Node):
 def test_WriteOutput(proj_path, lazy, eager):
     with zntrack.config.updated_config(lazy=lazy):
         with zntrack.Project() as project:
-            node = WriteOutput(value=42)
+            node = zntrack.examples.ParamsToOuts(params=42)
         project.run(eager=eager)
 
         if not eager:
             node.load()
         if lazy and not eager:
-            assert node.__dict__["output"] is LazyOption
+            assert node.__dict__["outs"] is LazyOption
         else:
-            assert node.__dict__["output"] is 42
+            assert node.__dict__["outs"] is 42
         assert node.output == 42
 
 
@@ -44,30 +26,30 @@ def test_WriteOutput(proj_path, lazy, eager):
 def test_CollectOutputs(proj_path, lazy, eager):
     with zntrack.config.updated_config(lazy=lazy):
         with zntrack.Project() as project:
-            a = WriteOutput(value=17, name="a")
-            b = WriteOutput(value=42, name="b")
-            node = CollectOutputs(nodes=[a, b])
+            a = zntrack.examples.ParamsToOuts(params=17, name="a")
+            b = zntrack.examples.ParamsToOuts(params=42, name="b")
+            node = zntrack.examples.AddNumbers(numbers=[a, b])
         project.run(eager=eager)
 
         if not eager:
             node.load()
         if lazy and not eager:
-            assert node.__dict__["output"] is LazyOption
-            assert node.__dict__["nodes"] is LazyOption
-            assert node.nodes[0].__dict__["output"] is LazyOption
-            assert node.nodes[1].__dict__["output"] is LazyOption
+            assert node.__dict__["sum"] is LazyOption
+            assert node.__dict__["numbers"] is LazyOption
+            assert node.numbers[0].__dict__["outs"] is LazyOption
+            assert node.numbers[1].__dict__["outs"] is LazyOption
         else:
-            assert node.__dict__["output"] is 59
-            assert node.__dict__["nodes"][0].name == "a"
-            assert node.__dict__["nodes"][1].name == "b"
+            assert node.__dict__["sum"] is 59
+            assert node.__dict__["numbers"][0].name == "a"
+            assert node.__dict__["numbers"][1].name == "b"
 
-        assert node.nodes[0].output == 17
-        assert node.nodes[1].output == 42
-        assert node.output == 59
+        assert node.numbers[0].outs == 17
+        assert node.numbers[1].outs == 42
+        assert node.sum == 59
 
         if not eager:
             # Check that non-lazy loading works
             node = node.from_rev(lazy=False)
-            assert node.__dict__["output"] is 59
-            assert node.__dict__["nodes"][0].name == "a"
-            assert node.__dict__["nodes"][1].name == "b"
+            assert node.__dict__["sum"] is 59
+            assert node.__dict__["numbers"][0].name == "a"
+            assert node.__dict__["numbers"][1].name == "b"

--- a/tests/integration/test_lazy_loading.py
+++ b/tests/integration/test_lazy_loading.py
@@ -6,7 +6,7 @@ from zntrack.utils import LazyOption
 
 @pytest.mark.parametrize("eager", [True, False])
 @pytest.mark.parametrize("lazy", [True, False])
-def test_WriteOutput(proj_path, lazy, eager):
+def test_ParamsToOuts(proj_path, lazy, eager):
     with zntrack.config.updated_config(lazy=lazy):
         with zntrack.Project() as project:
             node = zntrack.examples.ParamsToOuts(params=42)
@@ -18,7 +18,7 @@ def test_WriteOutput(proj_path, lazy, eager):
             assert node.__dict__["outs"] is LazyOption
         else:
             assert node.__dict__["outs"] is 42
-        assert node.output == 42
+        assert node.outs == 42
 
 
 @pytest.mark.parametrize("eager", [True, False])

--- a/tests/integration/test_list_deps.py
+++ b/tests/integration/test_list_deps.py
@@ -1,36 +1,15 @@
 """Test for [NodeAttribute] as 'zn.deps'."""
 import dvc.cli
 
-from zntrack import Node, zn
-
-
-class GenerateOutput(Node):
-    """Generate an output."""
-
-    inputs: int = zn.params()
-    output: int = zn.outs()
-
-    def run(self):
-        self.output = self.inputs
-
-
-class SumNumbers(Node):
-    """Sum a list of numbers."""
-
-    inputs: list = zn.deps()
-    shift: int = zn.params()
-    output: int = zn.outs()
-
-    def run(self):
-        self.output = sum(self.inputs) + self.shift
+import zntrack.examples
 
 
 def test_list_deps(proj_path):
-    node1 = GenerateOutput(inputs=1, name="node1")
-    node2 = GenerateOutput(inputs=2, name="node2")
+    node1 = zntrack.examples.ParamsToOuts(params=1, name="node1")
+    node2 = zntrack.examples.ParamsToOuts(params=2, name="node2")
 
-    data = [node1 @ "output", node2 @ "output"]
-    node3 = SumNumbers(inputs=data, shift=10)
+    data = [node1 @ "outs", node2 @ "outs"]
+    node3 = zntrack.examples.SumNodeAttributes(data, shift=10)
 
     node1.write_graph()
     node2.write_graph()
@@ -42,6 +21,6 @@ def test_list_deps(proj_path):
     node2.load()
     node3.load()
 
-    assert node1.output == 1
-    assert node2.output == 2
+    assert node1.outs == 1
+    assert node2.outs == 2
     assert node3.output == 13

--- a/tests/integration/test_node_node.py
+++ b/tests/integration/test_node_node.py
@@ -1,42 +1,15 @@
 import dvc.cli
 import pytest
 
-import zntrack
-
-
-class AddNumbers(zntrack.Node):
-    a = zntrack.zn.params()
-    b = zntrack.zn.params()
-    c = zntrack.zn.outs()
-
-    def run(self):
-        self.c = self.a + self.b
-
-
-class AddNodes(zntrack.Node):
-    a = zntrack.zn.deps()
-    b = zntrack.zn.deps()
-    c = zntrack.zn.outs()
-
-    def run(self):
-        self.c = self.a.c + self.b.c
-
-
-class AddNodeAttributes(zntrack.Node):
-    a = zntrack.zn.deps()
-    b = zntrack.zn.deps()
-    c = zntrack.zn.outs()
-
-    def run(self):
-        self.c = self.a + self.b
+import zntrack.examples
 
 
 @pytest.mark.parametrize("eager", [True, False])
 def test_AddNodes(proj_path, eager):
     with zntrack.Project() as project:
-        add_numbers_a = AddNumbers(a=1, b=2, name="AddNumbersA")
-        add_numbers_b = AddNumbers(a=1, b=3, name="AddNumbersB")
-        add_nodes = AddNodes(a=add_numbers_a, b=add_numbers_b)
+        add_numbers_a = zntrack.examples.AddNumbers(a=1, b=2, name="AddNumbersA")
+        add_numbers_b = zntrack.examples.AddNumbers(a=1, b=3, name="AddNumbersB")
+        add_nodes = zntrack.examples.AddNodes(a=add_numbers_a, b=add_numbers_b)
 
     assert not add_numbers_a.state.loaded
     assert not add_numbers_b.state.loaded
@@ -58,9 +31,11 @@ def test_AddNodes(proj_path, eager):
 @pytest.mark.parametrize("eager", [True, False])
 def test_AddNodeAttributes(proj_path, eager):
     with zntrack.Project() as project:
-        add_numbers_a = AddNumbers(a=1, b=2, name="AddNumbersA")
-        add_numbers_b = AddNumbers(a=1, b=3, name="AddNumbersB")
-        add_nodes = AddNodeAttributes(a=add_numbers_a.c, b=add_numbers_b.c)
+        add_numbers_a = zntrack.examples.AddNumbers(a=1, b=2, name="AddNumbersA")
+        add_numbers_b = zntrack.examples.AddNumbers(a=1, b=3, name="AddNumbersB")
+        add_nodes = zntrack.examples.AddNodeAttributes(
+            a=add_numbers_a.c, b=add_numbers_b.c
+        )
 
     assert not add_numbers_a.state.loaded
     assert not add_numbers_b.state.loaded
@@ -80,9 +55,11 @@ def test_AddNodeAttributes(proj_path, eager):
 
 
 def test_AddNodes_legacy(proj_path):
-    add_numbers_a = AddNumbers(a=1, b=2, name="AddNumbersA")
-    add_numbers_b = AddNumbers(a=1, b=3, name="AddNumbersB")
-    add_nodes = AddNodeAttributes(a=add_numbers_a @ "c", b=add_numbers_b @ "c")
+    add_numbers_a = zntrack.examples.AddNumbers(a=1, b=2, name="AddNumbersA")
+    add_numbers_b = zntrack.examples.AddNumbers(a=1, b=3, name="AddNumbersB")
+    add_nodes = zntrack.examples.AddNodeAttributes(
+        a=add_numbers_a @ "c", b=add_numbers_b @ "c"
+    )
 
     add_numbers_a.write_graph()
     add_numbers_b.write_graph()
@@ -106,9 +83,9 @@ def test_AddNodes_legacy(proj_path):
 
 
 def test_AddNodeAttributes_legacy(proj_path):
-    add_numbers_a = AddNumbers(a=1, b=2, name="AddNumbersA")
-    add_numbers_b = AddNumbers(a=1, b=3, name="AddNumbersB")
-    add_nodes = AddNodes(a=add_numbers_a, b=add_numbers_b)
+    add_numbers_a = zntrack.examples.AddNumbers(a=1, b=2, name="AddNumbersA")
+    add_numbers_b = zntrack.examples.AddNumbers(a=1, b=3, name="AddNumbersB")
+    add_nodes = zntrack.examples.AddNodes(a=add_numbers_a, b=add_numbers_b)
 
     add_numbers_a.write_graph()
     add_numbers_b.write_graph()

--- a/tests/integration/test_single_node.py
+++ b/tests/integration/test_single_node.py
@@ -3,22 +3,13 @@ import pathlib
 import pytest
 import yaml
 
-import zntrack
-
-
-class AddNumbers(zntrack.Node):
-    a = zntrack.zn.params()
-    b = zntrack.zn.params()
-    c = zntrack.zn.outs()
-
-    def run(self):
-        self.c = self.a + self.b
+import zntrack.examples
 
 
 @pytest.mark.parametrize("eager", [True, False])
 def test_AddNumbers(proj_path, eager):
     with zntrack.Project() as project:
-        add_numbers = AddNumbers(a=1, b=2)
+        add_numbers = zntrack.examples.AddNumbers(a=1, b=2)
 
     assert not add_numbers.state.loaded
 
@@ -31,7 +22,7 @@ def test_AddNumbers(proj_path, eager):
 
 def test_AddNumbers_remove_params(proj_path):
     with zntrack.Project() as project:
-        add_numbers = AddNumbers(a=1, b=2)
+        add_numbers = zntrack.examples.AddNumbers(a=1, b=2)
 
     assert not add_numbers.state.loaded
 
@@ -49,7 +40,7 @@ def test_AddNumbers_remove_params(proj_path):
 
 def test_znrack_from_rev(proj_path):
     with zntrack.Project() as project:
-        add_numbers = AddNumbers(a=1, b=2)
+        add_numbers = zntrack.examples.AddNumbers(a=1, b=2)
 
     assert not add_numbers.state.loaded
 
@@ -65,8 +56,8 @@ def test_znrack_from_rev(proj_path):
 @pytest.mark.parametrize("eager", [True, False])
 def test_AddNumbers_named(proj_path, eager):
     with zntrack.Project() as project:
-        add_numbers_a = AddNumbers(a=1, b=2, name="NodeA")
-        add_numbers_b = AddNumbers(a=1, b=2, name="NodeB")
+        add_numbers_a = zntrack.examples.AddNumbers(a=1, b=2, name="NodeA")
+        add_numbers_b = zntrack.examples.AddNumbers(a=1, b=2, name="NodeB")
 
     assert not add_numbers_a.state.loaded
     assert not add_numbers_b.state.loaded
@@ -187,8 +178,8 @@ class NoOutsWritten(zntrack.Node):
 def test_outs_in_init(proj_path):
     with pytest.raises(TypeError):
         # outs can not be set
-        _ = AddNumbers(a=1, b=2, outs=3)
+        _ = zntrack.examples.AddNumbers(a=1, b=2, outs=3)
     with zntrack.Project() as project:
         with pytest.raises(TypeError):
             # outs can not be set
-            _ = AddNumbers(a=1, b=2, c=3)  # c is an output
+            _ = zntrack.examples.AddNumbers(a=1, b=2, c=3)  # c is an output

--- a/tests/integration/test_zn_plots.py
+++ b/tests/integration/test_zn_plots.py
@@ -1,25 +1,14 @@
-import pathlib
-import subprocess
-
 import pandas as pd
 import pandas.testing as pdt
 import pytest
-import yaml
 
-import zntrack
-
-
-class WritePlots(zntrack.Node):
-    plots: pd.DataFrame = zntrack.zn.plots()
-
-    def run(self):
-        self.plots = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+import zntrack.examples
 
 
 @pytest.mark.parametrize("eager", [True, False])
 def test_WritePlots(proj_path, eager):
     with zntrack.Project() as project:
-        plots = WritePlots()
+        plots = zntrack.examples.WritePlots()
 
     assert not plots.state.loaded
 

--- a/zntrack/examples/__init__.py
+++ b/zntrack/examples/__init__.py
@@ -1,0 +1,41 @@
+"""Collection of ZnTrack example Nodes.
+
+These nodes are primarily used for testing and demonstration purposes.
+"""
+import pandas as pd
+
+import zntrack
+
+
+class ParamsToOuts(zntrack.Node):
+    """Save params to outs."""
+
+    params = zntrack.zn.params()
+    outs = zntrack.zn.outs()
+
+    def run(self) -> None:
+        """Save params to outs."""
+        self.outs = self.params
+
+
+class ParamsToMetrics(zntrack.Node):
+    """Save params to metrics."""
+
+    params = zntrack.zn.params()
+    metrics = zntrack.zn.metrics()
+
+    def run(self) -> None:
+        """Save params to metrics."""
+        self.metrics = self.params
+
+
+class WritePlots(zntrack.Node):
+    """Generate a plot."""
+
+    plots: pd.DataFrame = zntrack.zn.plots()
+    x: list = zntrack.zn.params([1, 2, 3])
+    y: list = zntrack.zn.params([4, 5, 6])
+
+    def run(self):
+        """Write plots."""
+        self.plots = pd.DataFrame({"x": self.x, "y": self.y})

--- a/zntrack/examples/__init__.py
+++ b/zntrack/examples/__init__.py
@@ -77,7 +77,7 @@ class AddNodeAttributes(zntrack.Node):
         self.c = self.a + self.b
 
 
-class AddNumbers(zntrack.Node):
+class AddNodeNumbers(zntrack.Node):
     """Add up all 'x.outs' from the dependencies."""
 
     numbers: list = zntrack.zn.deps()

--- a/zntrack/examples/__init__.py
+++ b/zntrack/examples/__init__.py
@@ -39,3 +39,39 @@ class WritePlots(zntrack.Node):
     def run(self):
         """Write plots."""
         self.plots = pd.DataFrame({"x": self.x, "y": self.y})
+
+
+class AddNumbers(zntrack.Node):
+    """Add two numbers."""
+
+    a = zntrack.zn.params()
+    b = zntrack.zn.params()
+    c = zntrack.zn.outs()
+
+    def run(self):
+        """Add two numbers."""
+        self.c = self.a + self.b
+
+
+class AddNodes(zntrack.Node):
+    """Add two nodes."""
+
+    a: AddNumbers = zntrack.zn.deps()
+    b: AddNumbers = zntrack.zn.deps()
+    c = zntrack.zn.outs()
+
+    def run(self):
+        """Add two nodes."""
+        self.c = self.a.c + self.b.c
+
+
+class AddNodeAttributes(zntrack.Node):
+    """Add two node attributes."""
+
+    a: float = zntrack.zn.deps()
+    b: float = zntrack.zn.deps()
+    c = zntrack.zn.outs()
+
+    def run(self):
+        """Add two node attributes."""
+        self.c = self.a + self.b

--- a/zntrack/examples/__init__.py
+++ b/zntrack/examples/__init__.py
@@ -75,3 +75,37 @@ class AddNodeAttributes(zntrack.Node):
     def run(self):
         """Add two node attributes."""
         self.c = self.a + self.b
+
+
+class AddNumbers(zntrack.Node):
+    """Add up all 'x.outs' from the dependencies."""
+
+    numbers: list = zntrack.zn.deps()
+    sum: int = zntrack.zn.outs()
+
+    def run(self):
+        """Add up all 'x.outs' from the dependencies."""
+        self.sum = sum(x.outs for x in self.numbers)
+
+
+class SumNodeAttributes(zntrack.Node):
+    """Sum a list of numbers."""
+
+    inputs: list = zntrack.zn.deps()
+    shift: int = zntrack.zn.params()
+    output: int = zntrack.zn.outs()
+
+    def run(self) -> None:
+        """Sum a list of numbers."""
+        self.output = sum(self.inputs) + self.shift
+
+
+class AddOne(zntrack.Node):
+    """Add one to the number."""
+
+    number: int = zntrack.zn.deps()
+    outs: int = zntrack.zn.outs()
+
+    def run(self) -> None:
+        """Add one to the number."""
+        self.outs = self.number + 1


### PR DESCRIPTION
Add `from zntrack import examples` to have some example Nodes, primarily used for testing.

- exclude examples from codecov?