### PR TITLE
Access `*_path` with `node.use_tmp_paths`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ZnTrack"
-version = "0.7.1"
+version = "0.7.2"
 description = "Create, Run and Benchmark DVC Pipelines in Python"
 authors = ["zincwarecode <zincwarecode@gmail.com>"]
 license = "Apache-2.0"

--- a/tests/integration/test_dvc_outs.py
+++ b/tests/integration/test_dvc_outs.py
@@ -139,3 +139,25 @@ def test_use_tmp_paths(proj_path):
     with node4.state.use_tmp_paths():
         assert node4.outs == (node4.state.tmp_path / "data").as_posix()
         assert isinstance(node4.outs, str)
+
+
+def test_use_tmp_paths_multi(proj_path):
+    with zntrack.Project(automatic_node_names=True) as proj:
+        node = zntrack.examples.WriteMultipleDVCOuts(params=["Lorem", "Ipsum", "Dolor"])
+
+    proj.run()
+
+    assert node.get_outs_content() == ("Lorem", "Ipsum", "Dolor")
+
+    assert node.outs1 == pathlib.Path("nodes", "WriteMultipleDVCOuts", "output.txt")
+    assert node.outs2 == pathlib.Path("nodes", "WriteMultipleDVCOuts", "output2.txt")
+    assert node.outs3 == pathlib.Path("nodes", "WriteMultipleDVCOuts", "data")
+
+    with node.state.use_tmp_paths():
+        assert node.outs1 == (node.state.tmp_path / "output.txt")
+        assert node.outs2 == (node.state.tmp_path / "output2.txt")
+        assert node.outs3 == (node.state.tmp_path / "data")
+
+        assert pathlib.Path(node.outs1).read_text() == "Lorem"
+        assert pathlib.Path(node.outs2).read_text() == "Ipsum"
+        assert (pathlib.Path(node.outs3) / "file.txt").read_text() == "Dolor"

--- a/tests/integration/test_dvc_outs.py
+++ b/tests/integration/test_dvc_outs.py
@@ -110,23 +110,32 @@ def test_use_tmp_paths(proj_path):
         node2 = zntrack.examples.WriteDVCOutsPath(params="test2")
 
         node3 = zntrack.examples.WriteDVCOuts(params="test", outs="result.txt")
-        # node4 = zntrack.examples.WriteDVCOutsPath(params="test2", outs="results")
+        node4 = zntrack.examples.WriteDVCOutsPath(
+            params="test2", outs=(zntrack.nwd / "data").as_posix()
+        )
 
     proj.run()
 
     node.get_outs_content() == "test"
     node2.get_outs_content() == "test2"
     node3.get_outs_content() == "test"
-    # node4.get_outs_content() == "test2"
+    node4.get_outs_content() == "test2"
 
     assert node.outs == pathlib.Path("nodes", "WriteDVCOuts", "output.txt")
     assert node2.outs == pathlib.Path("nodes", "WriteDVCOutsPath", "data")
     assert node3.outs == "result.txt"
-    # assert node4.outs == "results"
+    assert isinstance(node4.outs, str)
+    assert node4.outs == pathlib.Path("nodes", "WriteDVCOutsPath_1", "data").as_posix()
 
     with node.state.use_tmp_paths():
         assert node.outs == node.state.tmp_path / "output.txt"
+        assert isinstance(node.outs, pathlib.PurePath)
     with node2.state.use_tmp_paths():
         assert node2.outs == node2.state.tmp_path / "data"
+        assert isinstance(node2.outs, pathlib.PurePath)
     with node3.state.use_tmp_paths():
-        assert node3.outs == node3.state.tmp_path / "result.txt"
+        assert node3.outs == (node3.state.tmp_path / "result.txt").as_posix()
+        assert isinstance(node3.outs, str)
+    with node4.state.use_tmp_paths():
+        assert node4.outs == (node4.state.tmp_path / "data").as_posix()
+        assert isinstance(node4.outs, str)

--- a/tests/integration/test_dvc_outs.py
+++ b/tests/integration/test_dvc_outs.py
@@ -1,7 +1,7 @@
 import pathlib
 import typing
 
-import zntrack
+import zntrack.examples
 from zntrack import Node, dvc, nwd
 
 
@@ -102,3 +102,22 @@ def test_SingleNodeDefaultNWD(proj_path):
     assert SingleNodeDefaultNWD.from_rev(name="SampleNode").path1 == pathlib.Path(
         "nodes", "SampleNode", "test.json"
     )
+
+
+def test_use_tmp_paths(proj_path):
+    with zntrack.Project() as proj:
+        node = zntrack.examples.WriteDVCOuts(params="test")
+        node2 = zntrack.examples.WriteDVCOutsPath(params="test2")
+
+    proj.run()
+
+    node.get_outs_content() == "test"
+    node2.get_outs_content() == "test2"
+
+    assert node.outs == pathlib.Path("nodes", "WriteDVCOuts", "output.txt")
+    assert node2.outs == pathlib.Path("nodes", "WriteDVCOutsPath", "data")
+
+    with node.state.use_tmp_paths():
+        assert node.outs == node.state.tmp_path / "output.txt"
+    with node2.state.use_tmp_paths():
+        assert node2.outs == node2.state.tmp_path / "data"

--- a/tests/integration/test_dvc_outs.py
+++ b/tests/integration/test_dvc_outs.py
@@ -104,7 +104,7 @@ def test_SingleNodeDefaultNWD(proj_path):
     )
 
 
-def test_use_tmp_paths(proj_path):
+def test_use_tmp_path(proj_path):
     with zntrack.Project(automatic_node_names=True) as proj:
         node = zntrack.examples.WriteDVCOuts(params="test")
         node2 = zntrack.examples.WriteDVCOutsPath(params="test2")
@@ -127,14 +127,14 @@ def test_use_tmp_paths(proj_path):
     assert isinstance(node4.outs, str)
     assert node4.outs == pathlib.Path("nodes", "WriteDVCOutsPath_1", "data").as_posix()
 
-    with node.state.use_tmp_paths():
+    with node.state.use_tmp_path():
         assert node.outs == pathlib.Path("nodes", "WriteDVCOuts", "output.txt")
-    with node2.state.use_tmp_paths():
+    with node2.state.use_tmp_path():
         assert node2.outs == pathlib.Path("nodes", "WriteDVCOutsPath", "data")
-    with node3.state.use_tmp_paths():
+    with node3.state.use_tmp_path():
         assert node3.outs == "result.txt"
         assert isinstance(node3.outs, str)
-    with node4.state.use_tmp_paths():
+    with node4.state.use_tmp_path():
         assert (
             node4.outs == pathlib.Path("nodes", "WriteDVCOutsPath_1", "data").as_posix()
         )
@@ -156,21 +156,21 @@ def test_use_tmp_paths(proj_path):
     assert isinstance(node4.outs, str)
     assert node4.outs == pathlib.Path("nodes", "WriteDVCOutsPath_1", "data").as_posix()
 
-    with node.state.use_tmp_paths():
+    with node.state.use_tmp_path():
         assert node.outs == node.state.tmp_path / "output.txt"
         assert isinstance(node.outs, pathlib.PurePath)
-    with node2.state.use_tmp_paths():
+    with node2.state.use_tmp_path():
         assert node2.outs == node2.state.tmp_path / "data"
         assert isinstance(node2.outs, pathlib.PurePath)
-    with node3.state.use_tmp_paths():
+    with node3.state.use_tmp_path():
         assert node3.outs == (node3.state.tmp_path / "result.txt").as_posix()
         assert isinstance(node3.outs, str)
-    with node4.state.use_tmp_paths():
+    with node4.state.use_tmp_path():
         assert node4.outs == (node4.state.tmp_path / "data").as_posix()
         assert isinstance(node4.outs, str)
 
 
-def test_use_tmp_paths_multi(proj_path):
+def test_use_tmp_path_multi(proj_path):
     with zntrack.Project(automatic_node_names=True) as proj:
         node = zntrack.examples.WriteMultipleDVCOuts(params=["Lorem", "Ipsum", "Dolor"])
 
@@ -182,7 +182,7 @@ def test_use_tmp_paths_multi(proj_path):
     assert node.outs2 == pathlib.Path("nodes", "WriteMultipleDVCOuts", "output2.txt")
     assert node.outs3 == pathlib.Path("nodes", "WriteMultipleDVCOuts", "data")
 
-    with node.state.use_tmp_paths():
+    with node.state.use_tmp_path():
         assert node.outs1 == pathlib.Path("nodes", "WriteMultipleDVCOuts", "output.txt")
         assert node.outs2 == pathlib.Path("nodes", "WriteMultipleDVCOuts", "output2.txt")
         assert node.outs3 == pathlib.Path("nodes", "WriteMultipleDVCOuts", "data")
@@ -193,7 +193,7 @@ def test_use_tmp_paths_multi(proj_path):
 
     node = node.from_rev(remote=".")  # fake remote by passing the current directory
 
-    with node.state.use_tmp_paths():
+    with node.state.use_tmp_path():
         assert node.outs1 == (node.state.tmp_path / "output.txt")
         assert node.outs2 == (node.state.tmp_path / "output2.txt")
         assert node.outs3 == (node.state.tmp_path / "data")
@@ -203,7 +203,7 @@ def test_use_tmp_paths_multi(proj_path):
         assert (pathlib.Path(node.outs3) / "file.txt").read_text() == "Dolor"
 
 
-def test_use_tmp_paths_sequence(proj_path):
+def test_use_tmp_path_sequence(proj_path):
     with zntrack.Project(automatic_node_names=True) as proj:
         node = zntrack.examples.WriteDVCOutsSequence(
             params=["Lorem", "Ipsum", "Dolor"],
@@ -221,7 +221,7 @@ def test_use_tmp_paths_sequence(proj_path):
     for outs in node.outs:
         assert pathlib.Path(outs).exists()
 
-    with node.state.use_tmp_paths():
+    with node.state.use_tmp_path():
         for outs in node.outs:
             assert pathlib.Path(outs).exists()
             assert pathlib.Path(outs).read_text() in ("Lorem", "Ipsum", "Dolor")
@@ -233,7 +233,7 @@ def test_use_tmp_paths_sequence(proj_path):
 
     node = node.from_rev(remote=".")  # fake remote by passing the current directory
 
-    with node.state.use_tmp_paths():
+    with node.state.use_tmp_path():
         for outs in node.outs:
             assert pathlib.Path(outs).exists()
             assert pathlib.Path(outs).read_text() in ("Lorem", "Ipsum", "Dolor")
@@ -242,7 +242,7 @@ def test_use_tmp_paths_sequence(proj_path):
     assert node.get_outs_content() == ["Lorem", "Ipsum", "Dolor"]
 
 
-def test_use_tmp_paths_exp(tmp_path_2):
+def test_use_tmp_path_exp(tmp_path_2):
     with zntrack.Project(automatic_node_names=True) as proj:
         node = zntrack.examples.WriteDVCOuts(params="test")
 
@@ -260,7 +260,7 @@ def test_use_tmp_paths_exp(tmp_path_2):
     node1 = exp1["WriteDVCOuts"]
     assert node1.get_outs_content() == "test1"
 
-    with node1.state.use_tmp_paths():
+    with node1.state.use_tmp_path():
         assert node1.outs == node1.state.tmp_path / "output.txt"
         assert isinstance(node1.outs, pathlib.PurePath)
         assert pathlib.Path(node1.outs).read_text() == "test1"
@@ -269,7 +269,7 @@ def test_use_tmp_paths_exp(tmp_path_2):
     node2 = exp2["WriteDVCOuts"]
     assert node2.get_outs_content() == "test2"
 
-    with node2.state.use_tmp_paths():
+    with node2.state.use_tmp_path():
         assert node2.outs == node2.state.tmp_path / "output.txt"
         assert isinstance(node2.outs, pathlib.PurePath)
         assert pathlib.Path(node2.outs).read_text() == "test2"
@@ -277,6 +277,6 @@ def test_use_tmp_paths_exp(tmp_path_2):
     assert node.get_outs_content() == "test"
     assert node.outs == pathlib.Path("nodes", "WriteDVCOuts", "output.txt")
 
-    with node.state.use_tmp_paths():
+    with node.state.use_tmp_path():
         assert node.outs == pathlib.Path("nodes", "WriteDVCOuts", "output.txt")
         assert pathlib.Path(node.outs).read_text() == "test"

--- a/tests/integration/test_dvc_outs.py
+++ b/tests/integration/test_dvc_outs.py
@@ -105,19 +105,28 @@ def test_SingleNodeDefaultNWD(proj_path):
 
 
 def test_use_tmp_paths(proj_path):
-    with zntrack.Project() as proj:
+    with zntrack.Project(automatic_node_names=True) as proj:
         node = zntrack.examples.WriteDVCOuts(params="test")
         node2 = zntrack.examples.WriteDVCOutsPath(params="test2")
+
+        node3 = zntrack.examples.WriteDVCOuts(params="test", outs="result.txt")
+        # node4 = zntrack.examples.WriteDVCOutsPath(params="test2", outs="results")
 
     proj.run()
 
     node.get_outs_content() == "test"
     node2.get_outs_content() == "test2"
+    node3.get_outs_content() == "test"
+    # node4.get_outs_content() == "test2"
 
     assert node.outs == pathlib.Path("nodes", "WriteDVCOuts", "output.txt")
     assert node2.outs == pathlib.Path("nodes", "WriteDVCOutsPath", "data")
+    assert node3.outs == "result.txt"
+    # assert node4.outs == "results"
 
     with node.state.use_tmp_paths():
         assert node.outs == node.state.tmp_path / "output.txt"
     with node2.state.use_tmp_paths():
         assert node2.outs == node2.state.tmp_path / "data"
+    with node3.state.use_tmp_paths():
+        assert node3.outs == node3.state.tmp_path / "result.txt"

--- a/tests/test_zntrack.py
+++ b/tests/test_zntrack.py
@@ -5,4 +5,4 @@ from zntrack import __version__
 
 def test_version():
     """Test 'ZnTrack' version."""
-    assert __version__ == "0.7.1"
+    assert __version__ == "0.7.2"

--- a/zntrack/core/node.py
+++ b/zntrack/core/node.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import pathlib
+import tempfile
 import time
 import typing
 import unittest.mock
@@ -58,6 +59,7 @@ class NodeStatus:
     results: "NodeStatusResults"
     remote: str = None
     rev: str = None
+    tmp_path: pathlib.Path = dataclasses.field(default=None, init=False, repr=False)
 
     @functools.cached_property
     def fs(self) -> dvc.api.DVCFileSystem:
@@ -103,6 +105,23 @@ class NodeStatus:
                 with unittest.mock.patch("os.listdir", _listdir):
                     # Jupyter Notebooks replace open with io.open
                     yield
+
+    @contextlib.contextmanager
+    def use_tmp_paths(self, path: pathlib.Path = None) -> typing.ContextManager:
+        """Load the data for '*_path' into a temporary directory.
+
+        If you can not use 'node.state.fs.open' you can use
+        this as an alternative. This will load the data into
+        a temporary directory and then delete it afterwards.
+        The respective paths 'node.*_path' will be replaced
+        automatically inside the context manager.
+        """
+        if path is not None:
+            raise NotImplementedError("Custom paths are not implemented yet.")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.tmp_path = pathlib.Path(tmpdir)
+            yield
+            self.tmp_path = None
 
 
 class _NameDescriptor(zninit.Descriptor):

--- a/zntrack/core/node.py
+++ b/zntrack/core/node.py
@@ -56,7 +56,7 @@ class NodeStatus:
         The revision of the Node. This could be the current "HEAD" or a specific revision.
     tmp_path : pathlib.Path, default = DISABLE_TMP_PATH|None
         The temporary path used for loading the data.
-        This is only set within the context manager 'use_tmp_paths'.
+        This is only set within the context manager 'use_tmp_path'.
         If neither 'remote' nor 'rev' are set, tmp_path will not be used.
     """
 
@@ -114,7 +114,7 @@ class NodeStatus:
                     yield
 
     @contextlib.contextmanager
-    def use_tmp_paths(self, path: pathlib.Path = None) -> typing.ContextManager:
+    def use_tmp_path(self, path: pathlib.Path = None) -> typing.ContextManager:
         """Load the data for '*_path' into a temporary directory.
 
         If you can not use 'node.state.fs.open' you can use

--- a/zntrack/core/node.py
+++ b/zntrack/core/node.py
@@ -120,8 +120,15 @@ class NodeStatus:
             raise NotImplementedError("Custom paths are not implemented yet.")
         with tempfile.TemporaryDirectory() as tmpdir:
             self.tmp_path = pathlib.Path(tmpdir)
-            yield
-            self.tmp_path = None
+            log.debug(f"Using temporary directory {self.tmp_path}")
+            try:
+                yield
+            finally:
+                files = list(self.tmp_path.glob("**/*"))
+                log.debug(
+                    f"Deleting temporary directory {self.tmp_path} containing {files}"
+                )
+                self.tmp_path = None
 
 
 class _NameDescriptor(zninit.Descriptor):

--- a/zntrack/core/node.py
+++ b/zntrack/core/node.py
@@ -25,6 +25,7 @@ import znjson
 from zntrack import exceptions
 from zntrack.notebooks.jupyter import jupyter_class_to_file
 from zntrack.utils import (
+    DISABLE_TMP_PATH,
     NodeName,
     NodeStatusResults,
     config,
@@ -53,13 +54,19 @@ class NodeStatus:
         a "remote" location, such as a git repository.
     rev : str, default = None
         The revision of the Node. This could be the current "HEAD" or a specific revision.
+    tmp_path : pathlib.Path, default = DISABLE_TMP_PATH|None
+        The temporary path used for loading the data.
+        This is only set within the context manager 'use_tmp_paths'.
+        If neither 'remote' nor 'rev' are set, tmp_path will not be used.
     """
 
     loaded: bool
     results: "NodeStatusResults"
     remote: str = None
     rev: str = None
-    tmp_path: pathlib.Path = dataclasses.field(default=None, init=False, repr=False)
+    tmp_path: pathlib.Path = dataclasses.field(
+        default=DISABLE_TMP_PATH, init=False, repr=False
+    )
 
     @functools.cached_property
     def fs(self) -> dvc.api.DVCFileSystem:
@@ -115,20 +122,27 @@ class NodeStatus:
         a temporary directory and then delete it afterwards.
         The respective paths 'node.*_path' will be replaced
         automatically inside the context manager.
+
+        This is only set, if either 'remote' or 'rev' are set.
+        Otherwise, the data will be loaded from the current directory.
         """
         if path is not None:
             raise NotImplementedError("Custom paths are not implemented yet.")
-        with tempfile.TemporaryDirectory() as tmpdir:
-            self.tmp_path = pathlib.Path(tmpdir)
-            log.debug(f"Using temporary directory {self.tmp_path}")
-            try:
-                yield
-            finally:
-                files = list(self.tmp_path.glob("**/*"))
-                log.debug(
-                    f"Deleting temporary directory {self.tmp_path} containing {files}"
-                )
-                self.tmp_path = None
+
+        if self.tmp_path is DISABLE_TMP_PATH:
+            yield
+        else:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                self.tmp_path = pathlib.Path(tmpdir)
+                log.debug(f"Using temporary directory {self.tmp_path}")
+                try:
+                    yield
+                finally:
+                    files = list(self.tmp_path.glob("**/*"))
+                    log.debug(
+                        f"Deleting temporary directory {self.tmp_path} containing {files}"
+                    )
+                    self.tmp_path = None
 
 
 class _NameDescriptor(zninit.Descriptor):
@@ -342,6 +356,11 @@ class Node(zninit.ZnInit, znflow.Node):
         kwargs = {} if lazy is None else {"lazy": lazy}
         with config.updated_config(**kwargs):
             node.load(results=results)
+
+        if remote is not None or rev is not None:
+            # by default, tmp_path is disabled.
+            # if remote or rev is set, we enable it.
+            node.state.tmp_path = None
 
         return node
 

--- a/zntrack/examples/__init__.py
+++ b/zntrack/examples/__init__.py
@@ -141,7 +141,7 @@ class WriteDVCOuts(zntrack.Node):
 
     def get_outs_content(self):
         """Get the output file."""
-        with self.state.use_tmp_paths():
+        with self.state.use_tmp_path():
             return pathlib.Path(self.outs).read_text()
 
 
@@ -159,7 +159,7 @@ class WriteDVCOutsSequence(zntrack.Node):
     def get_outs_content(self):
         """Get the output file."""
         data = []
-        with self.state.use_tmp_paths():
+        with self.state.use_tmp_path():
             for path in self.outs:
                 data.append(pathlib.Path(path).read_text())
         return data
@@ -178,7 +178,7 @@ class WriteDVCOutsPath(zntrack.Node):
 
     def get_outs_content(self):
         """Get the output file."""
-        with self.state.use_tmp_paths():
+        with self.state.use_tmp_path():
             try:
                 return (pathlib.Path(self.outs) / "file.txt").read_text()
             except FileNotFoundError:
@@ -203,7 +203,7 @@ class WriteMultipleDVCOuts(zntrack.Node):
 
     def get_outs_content(self) -> t.Tuple[str, str, str]:
         """Get the output file."""
-        with self.state.use_tmp_paths():
+        with self.state.use_tmp_path():
             outs1_content = pathlib.Path(self.outs1).read_text()
             outs2_content = pathlib.Path(self.outs2).read_text()
             outs3_content = (pathlib.Path(self.outs3) / "file.txt").read_text()

--- a/zntrack/examples/__init__.py
+++ b/zntrack/examples/__init__.py
@@ -137,12 +137,12 @@ class WriteDVCOuts(zntrack.Node):
 
     def run(self):
         """Write an output file."""
-        self.outs.write_text(str(self.params))
+        pathlib.Path(self.outs).write_text(str(self.params))
 
     def get_outs_content(self):
         """Get the output file."""
         with self.state.use_tmp_paths():
-            return self.outs.read_text()
+            return pathlib.Path(self.outs).read_text()
 
 
 class WriteDVCOutsPath(zntrack.Node):
@@ -153,18 +153,13 @@ class WriteDVCOutsPath(zntrack.Node):
 
     def run(self):
         """Write an output file."""
-        self.outs.mkdir(parents=True, exist_ok=True)
-        (self.outs / "file.txt").write_text(str(self.params))
+        pathlib.Path(self.outs).mkdir(parents=True, exist_ok=True)
+        (pathlib.Path(self.outs) / "file.txt").write_text(str(self.params))
 
     def get_outs_content(self):
         """Get the output file."""
         with self.state.use_tmp_paths():
-            try:
-                return (self.outs / "file.txt").read_text()
-            except FileNotFoundError:
-                # print all files in the directory
-                files = list(self.outs.iterdir())
-                raise FileNotFoundError(f"File not found. Files in directory: {files}")
+            return (pathlib.Path(self.outs) / "file.txt").read_text()
 
 
 class ComputeRandomNumber(zntrack.Node):

--- a/zntrack/examples/__init__.py
+++ b/zntrack/examples/__init__.py
@@ -145,6 +145,26 @@ class WriteDVCOuts(zntrack.Node):
             return pathlib.Path(self.outs).read_text()
 
 
+class WriteDVCOutsSequence(zntrack.Node):
+    """Write an output file."""
+
+    params: list = zntrack.params()
+    outs: list | tuple | set | dict = zntrack.outs_path()
+
+    def run(self):
+        """Write an output file."""
+        for value, path in zip(self.params, self.outs):
+            pathlib.Path(path).write_text(str(value))
+
+    def get_outs_content(self):
+        """Get the output file."""
+        data = []
+        with self.state.use_tmp_paths():
+            for path in self.outs:
+                data.append(pathlib.Path(path).read_text())
+        return data
+
+
 class WriteDVCOutsPath(zntrack.Node):
     """Write an output file."""
 

--- a/zntrack/examples/__init__.py
+++ b/zntrack/examples/__init__.py
@@ -139,6 +139,33 @@ class WriteDVCOuts(zntrack.Node):
         """Write an output file."""
         self.outs.write_text(str(self.params))
 
+    def get_outs_content(self):
+        """Get the output file."""
+        with self.state.use_tmp_paths():
+            return self.outs.read_text()
+
+
+class WriteDVCOutsPath(zntrack.Node):
+    """Write an output file."""
+
+    params = zntrack.params()
+    outs = zntrack.outs_path(zntrack.nwd / "data")
+
+    def run(self):
+        """Write an output file."""
+        self.outs.mkdir(parents=True, exist_ok=True)
+        (self.outs / "file.txt").write_text(str(self.params))
+
+    def get_outs_content(self):
+        """Get the output file."""
+        with self.state.use_tmp_paths():
+            try:
+                return (self.outs / "file.txt").read_text()
+            except FileNotFoundError:
+                # print all files in the directory
+                files = list(self.outs.iterdir())
+                raise FileNotFoundError(f"File not found. Files in directory: {files}")
+
 
 class ComputeRandomNumber(zntrack.Node):
     """Compute a random number."""

--- a/zntrack/examples/__init__.py
+++ b/zntrack/examples/__init__.py
@@ -159,7 +159,11 @@ class WriteDVCOutsPath(zntrack.Node):
     def get_outs_content(self):
         """Get the output file."""
         with self.state.use_tmp_paths():
-            return (pathlib.Path(self.outs) / "file.txt").read_text()
+            try:
+                return (pathlib.Path(self.outs) / "file.txt").read_text()
+            except FileNotFoundError:
+                files = list(pathlib.Path(self.outs).iterdir())
+                raise ValueError(f"Expected {self.outs } file, found {files}.")
 
 
 class ComputeRandomNumber(zntrack.Node):

--- a/zntrack/examples/__init__.py
+++ b/zntrack/examples/__init__.py
@@ -166,6 +166,30 @@ class WriteDVCOutsPath(zntrack.Node):
                 raise ValueError(f"Expected {self.outs } file, found {files}.")
 
 
+class WriteMultipleDVCOuts(zntrack.Node):
+    """Write an output file."""
+
+    params = zntrack.params()
+    outs1 = zntrack.outs_path(zntrack.nwd / "output.txt")
+    outs2 = zntrack.outs_path(zntrack.nwd / "output2.txt")
+    outs3 = zntrack.outs_path(zntrack.nwd / "data")
+
+    def run(self):
+        """Write an output file."""
+        pathlib.Path(self.outs1).write_text(str(self.params[0]))
+        pathlib.Path(self.outs2).write_text(str(self.params[1]))
+        pathlib.Path(self.outs3).mkdir(parents=True, exist_ok=True)
+        (pathlib.Path(self.outs3) / "file.txt").write_text(str(self.params[2]))
+
+    def get_outs_content(self) -> t.Tuple[str, str, str]:
+        """Get the output file."""
+        with self.state.use_tmp_paths():
+            outs1_content = pathlib.Path(self.outs1).read_text()
+            outs2_content = pathlib.Path(self.outs2).read_text()
+            outs3_content = (pathlib.Path(self.outs3) / "file.txt").read_text()
+            return outs1_content, outs2_content, outs3_content
+
+
 class ComputeRandomNumber(zntrack.Node):
     """Compute a random number."""
 

--- a/zntrack/fields/dvc/options.py
+++ b/zntrack/fields/dvc/options.py
@@ -138,14 +138,16 @@ class DVCOption(Field):
         if instance.state.tmp_path is not None:
             # update nwd
             # move data to temp_path
-            if instance.state.fs.isdir(path.as_posix()):
+            if instance.state.fs.isdir(pathlib.Path(path).as_posix()):
                 instance.state.fs.get(
-                    path.as_posix(), instance.state.tmp_path.as_posix(), recursive=True
+                    pathlib.Path(path).as_posix(),
+                    instance.state.tmp_path.as_posix(),
+                    recursive=True,
                 )
-                return instance.state.tmp_path / path.name
+                return instance.state.tmp_path / pathlib.Path(path).name
             else:
-                temp_file = instance.state.tmp_path / path.name
-                instance.state.fs.get(path.as_posix(), temp_file.as_posix())
+                temp_file = instance.state.tmp_path / pathlib.Path(path).name
+                instance.state.fs.get(pathlib.Path(path).as_posix(), temp_file.as_posix())
                 return temp_file
         else:
             return path

--- a/zntrack/fields/dvc/options.py
+++ b/zntrack/fields/dvc/options.py
@@ -134,7 +134,21 @@ class DVCOption(Field):
         if instance is None:
             return self
         value = super().__get__(instance, owner)
-        return node_wd.ReplaceNWD()(value, nwd=get_nwd(instance))
+        path = node_wd.ReplaceNWD()(value, nwd=get_nwd(instance))
+        if instance.state.tmp_path is not None:
+            # update nwd
+            # move data to temp_path
+            if instance.state.fs.isdir(path.as_posix()):
+                instance.state.fs.get(
+                    path.as_posix(), instance.state.tmp_path.as_posix(), recursive=True
+                )
+                return instance.state.tmp_path / path.name
+            else:
+                temp_file = instance.state.tmp_path / path.name
+                instance.state.fs.get(path.as_posix(), temp_file.as_posix())
+                return temp_file
+        else:
+            return path
 
 
 class PlotsOption(PlotsMixin, DVCOption):

--- a/zntrack/fields/dvc/options.py
+++ b/zntrack/fields/dvc/options.py
@@ -144,11 +144,17 @@ class DVCOption(Field):
                     instance.state.tmp_path.as_posix(),
                     recursive=True,
                 )
-                return instance.state.tmp_path / pathlib.Path(path).name
+                _path = instance.state.tmp_path / pathlib.Path(path).name
             else:
                 temp_file = instance.state.tmp_path / pathlib.Path(path).name
                 instance.state.fs.get(pathlib.Path(path).as_posix(), temp_file.as_posix())
-                return temp_file
+                _path = temp_file
+
+            if isinstance(value, pathlib.PurePath):
+                # TODO: support for lists/tuples/...
+                return _path
+            else:
+                return _path.as_posix()
         else:
             return path
 

--- a/zntrack/fields/dvc/options.py
+++ b/zntrack/fields/dvc/options.py
@@ -32,7 +32,6 @@ class _LoadIntoTmpPath(znflow.utils.IterableHandler):
             _path = temp_file
 
         if isinstance(path, pathlib.PurePath):
-            # TODO: support for lists/tuples/...
             return _path
         else:
             return _path.as_posix()

--- a/zntrack/fields/dvc/options.py
+++ b/zntrack/fields/dvc/options.py
@@ -8,7 +8,7 @@ import znflow.utils
 import znjson
 
 from zntrack.fields.field import Field, FieldGroup, PlotsMixin
-from zntrack.utils import get_nwd, node_wd
+from zntrack.utils import DISABLE_TMP_PATH, get_nwd, node_wd
 
 if typing.TYPE_CHECKING:
     from zntrack import Node
@@ -159,7 +159,7 @@ class DVCOption(Field):
             return self
         value = super().__get__(instance, owner)
         path = node_wd.ReplaceNWD()(value, nwd=get_nwd(instance))
-        if instance.state.tmp_path is not None:
+        if instance.state.tmp_path not in [None, DISABLE_TMP_PATH]:
             loader = _LoadIntoTmpPath()
             return loader(path, instance=instance)
         else:

--- a/zntrack/utils/__init__.py
+++ b/zntrack/utils/__init__.py
@@ -16,12 +16,13 @@ import znflow
 import znjson
 
 from zntrack.utils import cli
-from zntrack.utils.config import config
+from zntrack.utils.config import DISABLE_TMP_PATH, config
 
 __all__ = [
     "cli",
     "node_wd",
     "config",
+    "DISABLE_TMP_PATH",
 ]
 
 if t.TYPE_CHECKING:

--- a/zntrack/utils/config.py
+++ b/zntrack/utils/config.py
@@ -99,3 +99,19 @@ class Config:
 
 
 config = Config()
+
+
+class DISABLE_TMP_PATH:
+    """Identifier for disabling loading data into a temporary directory."""
+
+    def __init__(self) -> None:
+        """Prohibit instantiation."""
+        raise NotImplementedError("This class can not be instantiated.")
+
+    def __repr__(self) -> str:
+        """Provide better representation."""
+        return "DISABLE_TMP_PATH"
+
+    def __str__(self) -> str:
+        """Provide better representation."""
+        return "DISABLE_TMP_PATH"


### PR DESCRIPTION
In addition to:

```python
return self.state.fs.read_text(self.outs)
```
you can now use an actual directory through, for tools that do not support the `DVCFileSystem`
```python
with self.state.use_tmp_paths():
    return self.outs.read_text()
```

# Open questions
- How to avoid using the  temporary directory, if the data already exists within the cwd?
- loading multiple `*_path`
- what if the `*_path` is a list / dict / ... ?

- could this be a `from_rev` or `load` feature? Where you run:

```py
with zntrack.from_rev(node, use_tmp_path=True):
    ...
```

`use_tmp_path` vs `use_tmp_paths` ?