### PR TITLE
Add `self.state.run_count` and `self.state.restarted`

### DIFF
--- a/tests/integration/test_restarts.py
+++ b/tests/integration/test_restarts.py
@@ -1,0 +1,40 @@
+import subprocess
+
+import zntrack.examples
+
+
+def test_no_restart(tmp_path_2):
+    project = zntrack.Project()
+
+    with project:
+        node = zntrack.examples.NodeWithRestart(start=0)
+
+    project.run()
+
+    node.load()
+    assert node.count == 1
+    assert node.state.run_count == 1
+    assert node.state.restart is False
+
+
+def test_restarts(tmp_path_2):
+    project = zntrack.Project()
+
+    with project:
+        node = zntrack.examples.NodeWithRestart(start=0, raise_exception_until=1)
+
+    project.build()
+    # can not longer use project.run() because it will remove outputs, running manually
+    # this should raise an exception
+    subprocess.run(
+        ["zntrack", "run", "zntrack.examples.NodeWithRestart", "--name=NodeWithRestart"]
+    )
+    # this should succeed
+    subprocess.run(
+        ["zntrack", "run", "zntrack.examples.NodeWithRestart", "--name=NodeWithRestart"]
+    )
+
+    node.load()
+    assert node.count == 2
+    assert node.state.run_count == 2
+    assert node.state.restarted is True

--- a/tests/integration/test_restarts.py
+++ b/tests/integration/test_restarts.py
@@ -21,18 +21,20 @@ def test_restarts(tmp_path_2):
     project = zntrack.Project()
 
     with project:
-        node = zntrack.examples.NodeWithRestart(start=0, raise_exception_until=1)
+        node = zntrack.examples.NodeWithRestart(start=0, raise_exception_until=2)
 
     project.build()
     # can not longer use project.run() because it will remove outputs, running manually
     # this should raise an exception
-    subprocess.run(
+    results = subprocess.run(
         ["zntrack", "run", "zntrack.examples.NodeWithRestart", "--name=NodeWithRestart"]
     )
+    assert results.returncode == 1
     # this should succeed
-    subprocess.run(
+    results = subprocess.run(
         ["zntrack", "run", "zntrack.examples.NodeWithRestart", "--name=NodeWithRestart"]
     )
+    assert results.returncode == 0
 
     node.load()
     assert node.count == 2

--- a/zntrack/cli/__init__.py
+++ b/zntrack/cli/__init__.py
@@ -78,10 +78,10 @@ def run(node: str, name: str = None, meta_only: bool = False) -> None:
         cls(exec_func=True)
     elif issubclass(cls, Node):
         node: Node = cls.from_rev(name=name, results=False)
+        node.save(meta_only=True)
         if not meta_only:
             node.run()
             node.save(parameter=False)
-        node.save(meta_only=True)
     else:
         raise ValueError(f"Node {node} is not a ZnTrack Node.")
 

--- a/zntrack/core/node.py
+++ b/zntrack/core/node.py
@@ -67,6 +67,7 @@ class NodeStatus:
     tmp_path: pathlib.Path = dataclasses.field(
         default=DISABLE_TMP_PATH, init=False, repr=False
     )
+    _run_count: int = dataclasses.field(default=0, init=False, repr=False)
 
     @functools.cached_property
     def fs(self) -> dvc.api.DVCFileSystem:
@@ -143,6 +144,20 @@ class NodeStatus:
                         f"Deleting temporary directory {self.tmp_path} containing {files}"
                     )
                     self.tmp_path = None
+
+    def _increment_run_count(self) -> None:
+        """Increment the run count."""
+        self._run_count += 1
+
+    @property
+    def run_count(self) -> int:
+        """Get the run count."""
+        return self._run_count
+
+    @property
+    def restarted(self) -> bool:
+        """Whether the node was restarted."""
+        return self._run_count > 1
 
 
 class _NameDescriptor(zninit.Descriptor):
@@ -255,7 +270,11 @@ class Node(zninit.ZnInit, znflow.Node):
             # the meta data will only be written here.
             import json
 
-            (self.nwd / "node-meta.json").write_text(json.dumps({"uuid": str(self.uuid)}))
+            print(f"Saving meta data for {self.name} with {self.state.run_count} runs.")
+
+            (self.nwd / "node-meta.json").write_text(
+                json.dumps({"uuid": str(self.uuid), "run_count": self.state.run_count})
+            )
             return
 
         # TODO have an option to save and run dvc commit afterwards.
@@ -317,14 +336,14 @@ class Node(zninit.ZnInit, znflow.Node):
         except KeyError as err:
             raise exceptions.NodeNotAvailableError(self) from err
 
-        if results:
-            with contextlib.suppress(FileNotFoundError):
-                # If the uuid is available, we can assume that all data for
-                #  this Node is available.
-                with self.state.fs.open(get_nwd(self) / "node-meta.json") as f:
-                    node_meta = json.load(f)
-                    self._uuid = uuid.UUID(node_meta["uuid"])
-                    self.state.results = NodeStatusResults.AVAILABLE
+        with contextlib.suppress(FileNotFoundError):
+            # If the uuid is available, we can assume that all data for
+            #  this Node is available.
+            with self.state.fs.open(get_nwd(self) / "node-meta.json") as f:
+                node_meta = json.load(f)
+                self._uuid = uuid.UUID(node_meta["uuid"])
+                self.state._run_count = node_meta["run_count"]
+                self.state.results = NodeStatusResults.AVAILABLE
         # TODO: documentation about _post_init and _post_load_ and when they are called
 
         zntrack_config = json.loads(self.state.fs.read_text(config.files.zntrack))
@@ -367,6 +386,11 @@ class Node(zninit.ZnInit, znflow.Node):
             # by default, tmp_path is disabled.
             # if remote or rev is set, we enable it.
             node.state.tmp_path = None
+
+        if not results:
+            # if a node is loaded without results and saved afterwards,
+            #  we count this as a run.
+            node.state._increment_run_count()
 
         return node
 

--- a/zntrack/examples/__init__.py
+++ b/zntrack/examples/__init__.py
@@ -275,3 +275,24 @@ class SumRandomNumbersNamed(SumRandomNumbers):
     """Same as SumRandomNumbers but with a custom name."""
 
     _name_ = "custom_SumRandomNumbers"
+
+
+class NodeWithRestart(zntrack.Node):
+    """Node that restarts."""
+
+    start: int = zntrack.params()
+    raise_exception_until: int = zntrack.params(0)
+
+    count: int = zntrack.outs()
+
+    def run(self) -> None:
+        """Run the node.
+
+        Increments the count by one, for each run.
+        Check that the restart flag is set.
+        """
+        self.count = self.start + self.state.run_count
+        if self.state.run_count > 1:
+            assert self.state.restarted
+        if self.state.run_count < self.raise_exception_until:
+            raise ValueError("This is a test exception, simulating killing the Node.")


### PR DESCRIPTION
With this addition you can check, if your run has been manually restarted using `zntrack run <path> --name <name>`.
This is helpful, for HPC applications or other issues where your application writes checkpoints and you can not afford to rerun everything.

```python
class NodeWithRestart(zntrack.Node):
    """Node that restarts."""

    def run(self) -> None:

        if self.state.restared: 
              print(f"Run has been restarted {self.state.run_count} times")
              # handle restarts
```