### PR TITLE
Support `__getitem__` for Groups

### DIFF
--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -241,16 +241,14 @@ def test_group_nodes(tmp_path_2):
     assert group_2["Group2_ParamsToOuts_1"] == node_4
     assert group_3["NamedGrp_NodeA"] == node_5
     assert group_3["NamedGrp_NodeB"] == node_6
-    
 
     with pytest.raises(KeyError):
         group_1["NodeA"]
-    
+
     # test iter group
     assert list(group_1) == [node_1, node_2]
     assert list(group_2) == [node_3, node_4]
     assert list(group_3) == [node_5, node_6]
-
 
     assert group_1.name == "Group1"
     assert group_2.name == "Group2"

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -234,6 +234,15 @@ def test_group_nodes(tmp_path_2):
     assert group_3["NodeA"] == node_5
     assert group_3["NodeB"] == node_6
 
+    # test getitem with full name
+    assert group_1["Group1_ParamsToOuts"] == node_1
+    assert group_1["Group1_ParamsToOuts_1"] == node_2
+    assert group_2["Group2_ParamsToOuts"] == node_3
+    assert group_2["Group2_ParamsToOuts_1"] == node_4
+    assert group_3["NamedGrp_NodeA"] == node_5
+    assert group_3["NamedGrp_NodeB"] == node_6
+    
+
     with pytest.raises(KeyError):
         group_1["NodeA"]
     

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -213,6 +213,10 @@ def test_group_nodes(tmp_path_2):
     assert "Group2_ParamsToOuts_1" in group_2
     assert "NamedGrp_NodeA" in group_3
     assert "NamedGrp_NodeB" in group_3
+    assert "NamedGrp_NodeA" not in group_1
+    assert "NamedGrp_NodeB" not in group_1
+    assert "NamedGrp_NodeA" not in group_2
+    assert "NamedGrp_NodeB" not in group_2
 
     # test without group prefix
     assert "ParamsToOuts" in group_1
@@ -222,6 +226,21 @@ def test_group_nodes(tmp_path_2):
     assert "NodeA" in group_3
     assert "NodeB" in group_3
 
+    # test getitem with node name
+    assert group_1["ParamsToOuts"] == node_1
+    assert group_1["ParamsToOuts_1"] == node_2
+    assert group_2["ParamsToOuts"] == node_3
+    assert group_2["ParamsToOuts_1"] == node_4
+    assert group_3["NodeA"] == node_5
+    assert group_3["NodeB"] == node_6
+
+    with pytest.raises(KeyError):
+        group_1["NodeA"]
+    
+    # test iter group
+    assert list(group_1) == [node_1, node_2]
+    assert list(group_2) == [node_3, node_4]
+    assert list(group_3) == [node_5, node_6]
 
 
     assert group_1.name == "Group1"

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -194,6 +194,7 @@ def test_group_nodes(tmp_path_2):
 
     project.run()
 
+    # test nodes in groups
     assert node_1 in group_1
     assert node_2 in group_1
     assert node_3 not in group_1
@@ -204,6 +205,24 @@ def test_group_nodes(tmp_path_2):
     assert node_4 in group_2
     assert node_5 in group_3
     assert node_6 in group_3
+
+    # test node_names in project
+    assert "Group1_ParamsToOuts" in group_1
+    assert "Group1_ParamsToOuts_1" in group_1
+    assert "Group2_ParamsToOuts" in group_2
+    assert "Group2_ParamsToOuts_1" in group_2
+    assert "NamedGrp_NodeA" in group_3
+    assert "NamedGrp_NodeB" in group_3
+
+    # test without group prefix
+    assert "ParamsToOuts" in group_1
+    assert "ParamsToOuts_1" in group_1
+    assert "ParamsToOuts" in group_2
+    assert "ParamsToOuts_1" in group_2
+    assert "NodeA" in group_3
+    assert "NodeB" in group_3
+
+
 
     assert group_1.name == "Group1"
     assert group_2.name == "Group2"

--- a/zntrack/project/zntrack_project.py
+++ b/zntrack/project/zntrack_project.py
@@ -493,11 +493,11 @@ class NodeGroup:
         else:
             item = self._get_name_with_prefix(item)
         return item in [node.name for node in self.nodes]
-    
+
     def __iter__(self) -> typing.Iterator[Node]:
         """Iterate over the nodes in the group."""
         return iter(self.nodes)
-    
+
     def __getitem__(self, name: int) -> Node:
         """Get the Node from the group."""
         name = self._get_name_with_prefix(name)

--- a/zntrack/project/zntrack_project.py
+++ b/zntrack/project/zntrack_project.py
@@ -480,9 +480,13 @@ class NodeGroup:
     nwd: pathlib.Path
     nodes: list[Node]
 
-    def __contains__(self, item: Node) -> bool:
+    def __contains__(self, item: typing.Union[Node, str]) -> bool:
         """Check if the Node is in the group."""
-        return item in self.nodes
+        if isinstance(item, Node):
+            item = item.name
+        if not item.startswith(self.name):
+            item = f"{self.name}_{item}"
+        return item in [node.name for node in self.nodes]
 
     def __len__(self) -> int:
         """Get the number of nodes in the group."""

--- a/zntrack/project/zntrack_project.py
+++ b/zntrack/project/zntrack_project.py
@@ -480,13 +480,31 @@ class NodeGroup:
     nwd: pathlib.Path
     nodes: list[Node]
 
+    def _get_name_with_prefix(self, name: str) -> str:
+        """Get the name with the group prefix."""
+        if name.startswith(self.name):
+            return name
+        return f"{self.name}_{name}"
+
     def __contains__(self, item: typing.Union[Node, str]) -> bool:
         """Check if the Node is in the group."""
         if isinstance(item, Node):
             item = item.name
-        if not item.startswith(self.name):
-            item = f"{self.name}_{item}"
+        else:
+            item = self._get_name_with_prefix(item)
         return item in [node.name for node in self.nodes]
+    
+    def __iter__(self) -> typing.Iterator[Node]:
+        """Iterate over the nodes in the group."""
+        return iter(self.nodes)
+    
+    def __getitem__(self, name: int) -> Node:
+        """Get the Node from the group."""
+        name = self._get_name_with_prefix(name)
+        for node in self.nodes:
+            if node.name == name:
+                return node
+        raise KeyError(f"Node {name} not in group {self.name}")
 
     def __len__(self) -> int:
         """Get the number of nodes in the group."""


### PR DESCRIPTION
Fixes #773 by adding support for

```python
assert list(group_1) == [node_1, node_2]
group_1["ParamsToOuts"] == node_1
group_1["Group1_ParamsToOuts"] == node_1
"Group1_ParamsToOuts" in group_1
"ParamsToOuts" in group_1
```