### PR TITLE
Improve Graph Writing

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5669,21 +5669,21 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 
 [[package]]
 name = "znflow"
-version = "0.1.14"
+version = "0.2.0a0"
 description = "A general purpose framework for building and running computational graphs."
 optional = false
-python-versions = ">=3.8,<4.0"
+python-versions = ">=3.9,<4.0"
 files = [
-    {file = "znflow-0.1.14-py3-none-any.whl", hash = "sha256:f94f21cdaece949754e6dd5beaedfb078b9331ca49e32d9a2dfaa4ac1d8f8324"},
-    {file = "znflow-0.1.14.tar.gz", hash = "sha256:bf85dbb4c816a3c1ae98ed62f75feb10a22032e8bccf8d016ee6d406873c9c03"},
+    {file = "znflow-0.2.0a0-py3-none-any.whl", hash = "sha256:e9d8e9a3efb800fbd06959883e84ed4ef0b6fb7304b2c1262d5eac4617aa9d39"},
+    {file = "znflow-0.2.0a0.tar.gz", hash = "sha256:0c4279d30a6999938aff58b867c9ea9b7166b3d24c87794891bca2e96ac7f04c"},
 ]
 
 [package.dependencies]
-matplotlib = ">=3.6.3,<4.0.0"
-networkx = ">=3.0,<4.0"
+matplotlib = ">=3,<4"
+networkx = ">=3,<4"
 
 [package.extras]
-dask = ["bokeh (>=2.4.2,<3.0.0)", "dask (>=2022.12.1,<2023.0.0)", "dask-jobqueue (>=0.8.1,<0.9.0)", "distributed (>=2022.12.1,<2023.0.0)"]
+dask = ["bokeh (>=2,<3)", "dask (>=2022,<2023)", "dask-jobqueue (>=0.8,<0.9)", "distributed (>=2022,<2023)"]
 
 [[package]]
 name = "zninit"
@@ -5713,4 +5713,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0.0"
-content-hash = "cd187c08029a8632406528c1ac370397729406979b98390499726e26ff411c46"
+content-hash = "c7b4e0d280aa028c18c82c2567c0417ab055412837d88e9a88c878b916d37b2c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ typer = "^0.7"
 dot4dict = "^0.1"
 zninit = "^0.1"
 znjson = "^0.2"
-znflow = "^0.1"
+znflow = "0.2.0a0"
 varname = "^0.13"
 # for Python3.12 compatibliity
 pyzmq = "^25"

--- a/zntrack/fields/dependency.py
+++ b/zntrack/fields/dependency.py
@@ -302,3 +302,12 @@ class Dependency(LazyField):
                 entry.name = entry_name
 
         return entry
+    
+            
+    def get_dvc_data(self, instance: "Node") -> dict:
+        """Get the DVC data."""
+        return {"deps": [x.as_posix() for x in self.get_files(instance)]}
+
+    def get_zntrack_data(self, instance: "Node") -> dict:
+        """Get the zntrack data."""
+        return {self.name: getattr(instance, self.name)}

--- a/zntrack/fields/dependency.py
+++ b/zntrack/fields/dependency.py
@@ -302,8 +302,7 @@ class Dependency(LazyField):
                 entry.name = entry_name
 
         return entry
-    
-            
+
     def get_dvc_data(self, instance: "Node") -> dict:
         """Get the DVC data."""
         return {"deps": [x.as_posix() for x in self.get_files(instance)]}

--- a/zntrack/fields/dvc/options.py
+++ b/zntrack/fields/dvc/options.py
@@ -56,6 +56,44 @@ class DVCOption(Field):
         self.dvc_option = kwargs.pop("dvc_option")
         super().__init__(*args, **kwargs)
 
+    def get_dvc_data(self, instance: "Node") -> dict:
+        """Get the data to be saved to the dvc.yaml file.
+
+        Parameters
+        ----------
+        instance : Node
+            The node instance to get the data for.
+
+        Returns
+        -------
+        dict
+            The data to be saved to the dvc.yaml file.
+
+        """
+        return {self.dvc_option: self.get_files(instance)}
+
+    def get_zntrack_data(self, instance: "Node") -> dict:
+        """Get the data to be saved to the zntrack.json file.
+
+        Parameters
+        ----------
+        instance : Node
+            The node instance to get the data for.
+
+        Returns
+        -------
+        dict
+            The data to be saved to the zntrack.json file.
+
+        """
+        try:
+            value = instance.__dict__[self.name]
+        except KeyError:
+            # Taken from DVCOption.save.
+            # TODO: Should we return an empty dict if getattr fails?
+            value = getattr(instance, self.name)
+        return {self.name: {"_type": _get_import_path(value), "value": value}}
+
     def get_files(self, instance: "Node") -> list:
         """Get the files affected by this field.
 
@@ -168,3 +206,9 @@ class DVCOption(Field):
 
 class PlotsOption(PlotsMixin, DVCOption):
     """Field with DVC plots kwargs."""
+
+
+# TODO: How was this done previously?
+def _get_import_path(obj):
+    obj_type = type(obj)
+    return f"{obj_type.__module__}.{obj_type.__qualname__}"

--- a/zntrack/fields/field.py
+++ b/zntrack/fields/field.py
@@ -36,6 +36,7 @@ class Field(zninit.Descriptor, abc.ABC):
     ----------
     dvc_option : str
         The dvc command option for this field.
+
     """
 
     dvc_option: str = None
@@ -49,6 +50,7 @@ class Field(zninit.Descriptor, abc.ABC):
         ----------
         instance : Node
             The Node instance to save the field for.
+            
         """
         raise NotImplementedError
 
@@ -70,6 +72,7 @@ class Field(zninit.Descriptor, abc.ABC):
         -------
         list
             The affected files.
+
         """
         raise NotImplementedError
 
@@ -83,6 +86,7 @@ class Field(zninit.Descriptor, abc.ABC):
         lazy : bool, optional
             Whether to load the field lazily.
             This only applies to 'LazyField' classes.
+
         """
         try:
             instance.__dict__[self.name] = self.get_data(instance)
@@ -103,6 +107,7 @@ class Field(zninit.Descriptor, abc.ABC):
         -------
         typing.List[tuple]
             The stage add argument for this field.
+
         """
         return [
             (f"--{self.dvc_option}", pathlib.Path(x).as_posix())
@@ -127,6 +132,7 @@ class Field(zninit.Descriptor, abc.ABC):
         -------
         typing.List[str]
             The optional dvc commands.
+
         """
         return []
 
@@ -156,6 +162,18 @@ class Field(zninit.Descriptor, abc.ABC):
         with open(config.files.zntrack, "w") as f:
             json.dump(zntrack_dict, f, indent=4, cls=encoder)
 
+
+    def get_zntrack_data(self, instance: "Node") -> dict:
+        """Get the data that will be written to the zntrack config file."""
+        return {}
+
+    def get_dvc_data(self, instance: "Node") -> dict:
+        """Get the data that will be written to the dvc config file."""
+        return {}
+    
+    def get_params_data(self, instance: "Node") -> dict:
+        """Get the data that will be written to the params file."""
+        return {}
 
 class DataIsLazyError(Exception):
     """Exception to raise when a field is accessed that contains lazy data."""

--- a/zntrack/fields/field.py
+++ b/zntrack/fields/field.py
@@ -50,7 +50,7 @@ class Field(zninit.Descriptor, abc.ABC):
         ----------
         instance : Node
             The Node instance to save the field for.
-            
+
         """
         raise NotImplementedError
 
@@ -162,7 +162,6 @@ class Field(zninit.Descriptor, abc.ABC):
         with open(config.files.zntrack, "w") as f:
             json.dump(zntrack_dict, f, indent=4, cls=encoder)
 
-
     def get_zntrack_data(self, instance: "Node") -> dict:
         """Get the data that will be written to the zntrack config file."""
         return {}
@@ -170,10 +169,11 @@ class Field(zninit.Descriptor, abc.ABC):
     def get_dvc_data(self, instance: "Node") -> dict:
         """Get the data that will be written to the dvc config file."""
         return {}
-    
+
     def get_params_data(self, instance: "Node") -> dict:
         """Get the data that will be written to the params file."""
         return {}
+
 
 class DataIsLazyError(Exception):
     """Exception to raise when a field is accessed that contains lazy data."""

--- a/zntrack/fields/zn/options.py
+++ b/zntrack/fields/zn/options.py
@@ -274,7 +274,7 @@ class Plots(PlotsMixin, LazyField):
     def get_dvc_data(self, instance: "Node") -> dict:
         """Get the DVC data."""
         return {"plots": [x.as_posix() for x in self.get_files(instance)]}
-    
+
     def get_zntrack_data(self, instance: "Node") -> dict:
         """Get the zntrack data."""
         return {self.name: pathlib.Path(f"$nwd$/{self.name}.csv")}

--- a/zntrack/fields/zn/options.py
+++ b/zntrack/fields/zn/options.py
@@ -103,10 +103,19 @@ class Params(Field):
     ----------
     dvc_option: str
         The DVC option to use. Default is "params".
+
     """
 
     dvc_option: str = "params"
     group = FieldGroup.PARAMETER
+
+    def get_params_data(self, instance: "Node") -> dict:
+        """Get the parameters data."""
+        return {self.name: getattr(instance, self.name)}
+
+    def get_dvc_data(self, instance: "Node") -> dict:
+        """Get the DVC data."""
+        return {"params": [instance.name]}
 
     def get_files(self, instance: "Node") -> list:
         """Get the list of files affected by this field.
@@ -115,6 +124,7 @@ class Params(Field):
         -------
         list
             A list of file paths.
+
         """
         return [config.files.params]
 
@@ -125,6 +135,7 @@ class Params(Field):
         ----------
         instance : Node
             The node instance associated with this field.
+
         """
         file = self.get_files(instance)[0]
 
@@ -161,6 +172,7 @@ class Params(Field):
         -------
         list
             A list of tuples containing the DVC option and the file path.
+
         """
         file = self.get_files(instance)[0]
         return [(f"--{self.dvc_option}", f"{file}:{instance.name}")]
@@ -171,6 +183,14 @@ class Output(LazyField):
 
     group = FieldGroup.RESULT
 
+    def get_dvc_data(self, instance: "Node") -> dict:
+        """Get the DVC data."""
+        return {"outs": [x.as_posix() for x in self.get_files(instance)]}
+
+    def get_zntrack_data(self, instance: "Node") -> dict:
+        """Get the zntrack data."""
+        return {self.name: pathlib.Path(f"$nwd$/{self.name}.json")}
+
     def __init__(self, dvc_option: str, **kwargs):
         """Create a new Output field.
 
@@ -180,6 +200,7 @@ class Output(LazyField):
             The DVC option used to specify the output file.
         **kwargs
             Additional arguments to pass to the parent constructor.
+
         """
         self.dvc_option = dvc_option
         super().__init__(**kwargs)
@@ -196,6 +217,7 @@ class Output(LazyField):
         -------
         list
             A list containing the path of the file.
+
         """
         return [get_nwd(instance) / f"{self.name}.json"]
 
@@ -206,6 +228,7 @@ class Output(LazyField):
         ----------
         instance : Node
             The node instance.
+
         """
         try:
             value = self.get_value_except_lazy(instance)
@@ -236,6 +259,7 @@ class Output(LazyField):
         -------
         list
             A list containing the DVC command for this field.
+
         """
         file = self.get_files(instance)[0]
         return [(f"--{self.dvc_option}", file.as_posix())]
@@ -246,6 +270,14 @@ class Plots(PlotsMixin, LazyField):
 
     dvc_option: str = "plots"
     group = FieldGroup.RESULT
+
+    def get_dvc_data(self, instance: "Node") -> dict:
+        """Get the DVC data."""
+        return {"plots": [x.as_posix() for x in self.get_files(instance)]}
+    
+    def get_zntrack_data(self, instance: "Node") -> dict:
+        """Get the zntrack data."""
+        return {self.name: pathlib.Path(f"$nwd$/{self.name}.csv")}
 
     def get_files(self, instance) -> list:
         """Get the path of the file in the node directory."""

--- a/zntrack/utils/__init__.py
+++ b/zntrack/utils/__init__.py
@@ -225,7 +225,7 @@ def cwd_temp_dir(required_files=None) -> tempfile.TemporaryDirectory:
 class NodeName:
     """The name of a node."""
 
-    groups: list[str]
+    groups: znflow.Group
     name: str
     varname: str = None
     suffix: int = 0
@@ -235,7 +235,7 @@ class NodeName:
         """Get the node name."""
         name = []
         if self.groups is not None:
-            name.extend(self.groups)
+            name.extend(x for x in self.groups.names[0])
         if self.use_varname:
             name.append(self.varname)
         else:
@@ -255,7 +255,7 @@ class NodeName:
 
     def update_suffix(self, project: "Project", node: "Node") -> None:
         """Update the suffix."""
-        node_names = [x["value"].name for x in project.graph.nodes.values()]
+        # node_names = [x["value"].name for x in project.graph.nodes.values()]
         self.use_varname = project.magic_names
 
         node_names = []

--- a/zntrack/utils/__init__.py
+++ b/zntrack/utils/__init__.py
@@ -255,7 +255,6 @@ class NodeName:
 
     def update_suffix(self, project: "Project", node: "Node") -> None:
         """Update the suffix."""
-        # node_names = [x["value"].name for x in project.graph.nodes.values()]
         self.use_varname = project.magic_names
 
         node_names = []


### PR DESCRIPTION
Introduce new abstract methods, for all `zntrack.<field>` and `zntrack.<field>_path`.

```python
    def get_zntrack_data(self, instance: "Node") -> dict:
        """Get the data that will be written to the zntrack config file."""
        return {}

    def get_dvc_data(self, instance: "Node") -> dict:
        """Get the data that will be written to the dvc config file."""
        return {}

    def get_params_data(self, instance: "Node") -> dict:
        """Get the data that will be written to the params file."""
        return {}
```

- use https://github.com/iterative/dvc/pull/9606 in some way for `get_dvc_data`
- write pydantic scheme for the others