### PR TITLE
Add more tests for `zntrack.apply`

### DIFF
--- a/tests/integration/test_apply.py
+++ b/tests/integration/test_apply.py
@@ -27,6 +27,7 @@ def test_apply(proj_path, eager) -> None:
     assert b.outs == "a-b"
     assert c.outs == "a-b-c"
 
+
 @pytest.mark.parametrize("attribute", [True, False])
 @pytest.mark.parametrize("eager", [True, False])
 def test_deps_apply(proj_path, eager, attribute):
@@ -57,5 +58,4 @@ def test_deps_apply(proj_path, eager, attribute):
     assert isinstance(c, zntrack.Node)
     assert isinstance(x3, zntrack.Node)
 
-    assert x3.c == 'a-ba-b-c'
-
+    assert x3.c == "a-ba-b-c"

--- a/tests/integration/test_apply.py
+++ b/tests/integration/test_apply.py
@@ -26,3 +26,24 @@ def test_apply(proj_path, eager) -> None:
     assert a.outs == ["a", "b"]
     assert b.outs == "a-b"
     assert c.outs == "a-b-c"
+
+@pytest.mark.parametrize("eager", [True, False])
+def test_deps_apply(proj_path, eager):
+    """Test connecting applied nodes to other nodes."""
+
+    project = zntrack.Project()
+
+    JoinedParamsToOuts = zntrack.apply(zntrack.examples.ParamsToOuts, "join")
+
+    with project:
+        a = zntrack.examples.ParamsToOuts(params=["a", "b"])
+        b = JoinedParamsToOuts(params=["a", "b"])
+        c = zntrack.apply(zntrack.examples.ParamsToOuts, "join")(params=["a", "b", "c"])
+
+        x3 = zntrack.examples.AddNumbers(a=b.outs, b=c.outs)
+
+    project.run(eager=eager)
+
+    x3.load()
+
+    assert x3.c == 'a-ba-b-c'

--- a/tests/integration/test_apply.py
+++ b/tests/integration/test_apply.py
@@ -27,8 +27,9 @@ def test_apply(proj_path, eager) -> None:
     assert b.outs == "a-b"
     assert c.outs == "a-b-c"
 
+@pytest.mark.parametrize("attribute", [True, False])
 @pytest.mark.parametrize("eager", [True, False])
-def test_deps_apply(proj_path, eager):
+def test_deps_apply(proj_path, eager, attribute):
     """Test connecting applied nodes to other nodes."""
 
     project = zntrack.Project()
@@ -42,15 +43,19 @@ def test_deps_apply(proj_path, eager):
         b = JoinedParamsToOuts(params=["a", "b"])
         c = zntrack.apply(zntrack.examples.ParamsToOuts, "join")(params=["a", "b", "c"])
 
-        x3 = zntrack.examples.AddNumbers(a=b.outs, b=c.outs)
+        if attribute:
+            x3 = zntrack.examples.AddNodeAttributes(a=b.outs, b=c.outs)
+        else:
+            x3 = zntrack.examples.AddNodes2(a=b, b=c)
 
     project.run(eager=eager)
 
     x3.load()
-    
+
     assert isinstance(a, zntrack.Node)
     assert isinstance(b, zntrack.Node)
     assert isinstance(c, zntrack.Node)
     assert isinstance(x3, zntrack.Node)
 
     assert x3.c == 'a-ba-b-c'
+

--- a/tests/integration/test_apply.py
+++ b/tests/integration/test_apply.py
@@ -35,6 +35,8 @@ def test_deps_apply(proj_path, eager):
 
     JoinedParamsToOuts = zntrack.apply(zntrack.examples.ParamsToOuts, "join")
 
+    assert issubclass(JoinedParamsToOuts, zntrack.Node)
+
     with project:
         a = zntrack.examples.ParamsToOuts(params=["a", "b"])
         b = JoinedParamsToOuts(params=["a", "b"])
@@ -45,5 +47,10 @@ def test_deps_apply(proj_path, eager):
     project.run(eager=eager)
 
     x3.load()
+    
+    assert isinstance(a, zntrack.Node)
+    assert isinstance(b, zntrack.Node)
+    assert isinstance(c, zntrack.Node)
+    assert isinstance(x3, zntrack.Node)
 
     assert x3.c == 'a-ba-b-c'

--- a/zntrack/examples/__init__.py
+++ b/zntrack/examples/__init__.py
@@ -86,6 +86,17 @@ class AddNodes(zntrack.Node):
         """Add two nodes."""
         self.c = self.a.c + self.b.c
 
+class AddNodes2(zntrack.Node):
+    """Add two nodes."""
+
+    a: AddNumbers = zntrack.deps()
+    b: AddNumbers = zntrack.deps()
+    c = zntrack.outs()
+
+    def run(self):
+        """Add two nodes."""
+        self.c = self.a.outs + self.b.outs
+
 
 class AddNodeAttributes(zntrack.Node):
     """Add two node attributes."""

--- a/zntrack/examples/__init__.py
+++ b/zntrack/examples/__init__.py
@@ -86,6 +86,7 @@ class AddNodes(zntrack.Node):
         """Add two nodes."""
         self.c = self.a.c + self.b.c
 
+
 class AddNodes2(zntrack.Node):
     """Add two nodes."""
 


### PR DESCRIPTION
It was unclear if using a `zntrack.apply` `Node` as a dependency works, this PR shows that it does.