### PR TITLE
performance benchmarking

### DIFF
--- a/zntrack/state.py
+++ b/zntrack/state.py
@@ -26,6 +26,8 @@ if t.TYPE_CHECKING:
 PLUGIN_LIST = list[t.Type[ZnTrackPlugin]]
 PLUGIN_DICT = dict[str, ZnTrackPlugin]
 
+COUNT = 0
+
 
 @dataclasses.dataclass(frozen=True)
 class NodeStatus:
@@ -53,11 +55,19 @@ class NodeStatus:
     def nwd(self):
         if self.tmp_path is not None:
             return self.tmp_path
+        if "nwd" not in self.node.__dict__:
+            global COUNT
+            COUNT += 1
+            print(f"nwd: {COUNT}")
+        self.node.__dict__["nwd"] = get_nwd(self.node)
+
         return get_nwd(self.node)
 
     @property
     def fs(self) -> AbstractFileSystem:
         """Get the file system of the Node."""
+        # print("ACCESS FILE SYSTEM")
+        print("This should not be called during build.")
         if self.remote is None and self.rev is None:
             return LocalFileSystem()
         return dvc.api.DVCFileSystem(

--- a/zntrack/utils/misc.py
+++ b/zntrack/utils/misc.py
@@ -77,6 +77,8 @@ class TempPathLoader(znflow.utils.IterableHandler):
         nwd_handler = NWDReplaceHandler()
 
         original_nwd = get_nwd(instance)
+        if "nwd" not in instance.__dict__:
+            print("tmp-path-loader")
         tmp_nwd = instance.nwd
 
         original_path = pathlib.Path(nwd_handler(value, nwd=original_nwd))

--- a/zntrack/utils/node_wd.py
+++ b/zntrack/utils/node_wd.py
@@ -58,7 +58,7 @@ def get_nwd(node: "Node") -> pathlib.Path:
         if (
             node.state.remote is None
             and node.state.rev is None
-            and node.state.state == NodeStatusEnum.FINISHED
+            and node.state.state != NodeStatusEnum.FINISHED
         ):
             nwd = pathlib.Path(NWD_PATH, node.name)
         else:


### PR DESCRIPTION
- https://github.com/zincware/ZnFlow/blob/d1e6f5ddc75cf2849f546d9afd08ef271f843544/znflow/graph.py#L125 causes all the getters to fire and try to get the values. This would be okay if they were not trying to all read from file